### PR TITLE
Use pyproject as the single dependency contract

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
--r requirements.txt
+-e .
 pytest>=7.2,<9
 PyYAML>=6,<7
 build>=1,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,1 @@
-geopandas>=0.12.2,<2
-pandas>=1.4.4,<3
-numpy>=1.23,<3
-shapely>=2.0,<3
-pyogrio>=0.7,<1
-Jinja2>=3.0,<4
-matplotlib>=3.6,<4
-openpyxl>=3.0,<4
-xlrd>=2.0,<3
-requests>=2.28,<3
-jsonschema>=4.16,<5
+.


### PR DESCRIPTION
## Summary

- keep runtime dependency constraints only in `pyproject.toml`
- make `requirements.txt` install the project rather than duplicate every runtime dependency
- make `requirements-dev.txt` install the project in editable mode plus development-only tools

This removes one remaining source of version drift without changing the installed dependency set.

## Validation

GitHub Actions should run the full Python, browser, and clean-wheel matrix.