### PR TITLE
Rewrite README around product value and quick start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,11 @@ do not yet have Git tags or GitHub Releases.
   Made the packaged JSON Schema the single source of truth for the current MapSpec version.
 - 公共 `map-list` 演示仅保留固定数据快照，展示配置统一由演示构建器生成。
   Made the demo builder the sole source of truth for the public `map-list` configuration.
-- README 的模板展示改为以功能和优势为中心，并用用户选定的完整中文界面截图替换中文预览图。
-  Reframed the README template showcase around capabilities and advantages, and replaced the
-  Chinese previews with the user-selected full-interface screenshots.
+- 将英文主 README 与独立中文 README 分开，并围绕价值主张、在线演示、快速开始、模板选择、
+  输入输出和工程流程重新组织内容；同时移除已废弃的客户端 Plan mode 说明。
+  Split the English and Chinese READMEs and rewrote them around the value proposition, live
+  demos, quick start, product choice, inputs, deliverables, and engineering workflow while
+  removing obsolete client-specific Plan mode guidance.
 
 ### Fixed / 修复
 

--- a/README.md
+++ b/README.md
@@ -1,281 +1,98 @@
+<div align="center">
+
 # Interactive Map Builder
 
-[中文](#中文) · [English](#english) ·
-[中文在线演示](https://xlbaoxl.github.io/interactive-map-builder/zh-CN/) ·
-[English live demos](https://xlbaoxl.github.io/interactive-map-builder/en-US/)
+**Turn existing spatial data into polished, verified map products with an AI agent.**
 
-Build lightweight, searchable Leaflet maps and report-ready figures from existing spatial
-data—without a frontend build system.
+[![CI](https://github.com/xlbaoxl/interactive-map-builder/actions/workflows/ci.yml/badge.svg)](https://github.com/xlbaoxl/interactive-map-builder/actions/workflows/ci.yml)
+[![Python 3.9+](https://img.shields.io/badge/Python-3.9%2B-3776AB?logo=python&logoColor=white)](pyproject.toml)
+[![MapSpec 1.1](https://img.shields.io/badge/MapSpec-1.1-0f766e)](references/map-spec.md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-2ea44f.svg)](LICENSE)
 
----
+[Live demos](https://xlbaoxl.github.io/interactive-map-builder/) ·
+[中文说明](README.zh-CN.md) ·
+[Changelog](CHANGELOG.md)
 
-## 中文
+</div>
 
-Interactive Map Builder 是一个给 Codex 和其他 AI 助手使用的地图 Skill。把已有坐标或
-空间数据交给它，它会先检查数据和需要确认的选项，再生成可直接打开的交互地图、汇报图片
-和论文矢量图。
+[![Interactive Map Builder parcel explorer](assets/screenshots/en-US/map-list.png)](https://xlbaoxl.github.io/interactive-map-builder/en-US/map-list/)
 
-[查看更新日志](CHANGELOG.md)。
-
-### 预制模板与功能展示
-
-下面展示 Skill 内置的两种预制交互模板。截图均来自实际生成的 HTML 页面，不是另外制作
-的设计稿；示例数据来自 [NYC Open Data](assets/examples/SOURCES.md)，仅用于演示模板能力。
-在线演示需要联网加载街道底图。
-
-#### 地块分类统计
-
-- **功能：** 在同一页面中搜索名称、地址或属性，按地块类别筛选结果，查看汇总指标和
-  排序清单，并点击地块联动查看用途、分区、面积、容积率、楼层和建成年份等详情。
-- **优势：** 将空间分布、分类统计、对象清单与单体详情整合在一起，既能快速筛选目标，
-  也能保留完整的空间语境，适合地块、设施、项目和选址对象等清单型数据。
-
-[![地块分类统计模板，展示分类筛选、结果排序、汇总指标和地块详情](assets/screenshots/zh-CN/map-list.png)](https://xlbaoxl.github.io/interactive-map-builder/zh-CN/map-list/)
-
-[查看“地块分类统计”交互演示](https://xlbaoxl.github.io/interactive-map-builder/zh-CN/map-list/)
-
-#### 多图层可视化
-
-- **功能：** 在一张地图中叠加面、线、点等多类业务数据，按图层搜索，并通过图层开关、
-  分类图例、对象详情和底图切换控制展示内容。
-- **优势：** 便于比较不同主题数据的分布及其空间关系，减少在多张独立地图之间切换，
-  适合交通、规划、公共服务、生态环境等需要联合解读多个图层的场景。
-
-[![多图层可视化模板，展示业务图层搜索、图层开关、分类图例和对象详情](assets/screenshots/zh-CN/multilayer.png)](https://xlbaoxl.github.io/interactive-map-builder/zh-CN/multilayer/)
-
-[查看“多图层可视化”交互演示](https://xlbaoxl.github.io/interactive-map-builder/zh-CN/multilayer/)
-
-### 安装和使用（任选一种方法）
-
-#### 方法一：直接在 Codex 里安装
-
-1. 打开 Codex，创建一个新任务。
-2. 把下面这句话发给 Codex：
+Interactive Map Builder is a **Codex-first Agent Skill** for turning GeoJSON, GeoPackage,
+Shapefile, CSV, Excel, and ArcGIS data into shareable map products. The Skill inspects the data,
+closes only the requirements gaps the data cannot answer, writes an auditable MapSpec, builds a
+self-contained Leaflet app, verifies the result, and exports figures for slides and papers.
 
 ```text
-$skill-installer 请从 https://github.com/xlbaoxl/interactive-map-builder 安装这个 Skill，并安装它需要的 Python 依赖。
+Spatial data → inspect → confirm → MapSpec → build → browser QA → HTML + PNG/SVG/PDF
 ```
 
-3. 安装完成后创建一个新任务。如果新任务里没有出现这个 Skill，再重启一次 Codex。
+No frontend build system, no hand-written Folium page, and no hidden cleanup.
 
-#### 方法二：在 Windows PowerShell 里安装
+## Highlights
 
-1. 确认电脑已经安装
-   [Git](https://git-scm.com/download/win) 和
-   [Python 3.9 或更高版本](https://www.python.org/downloads/windows/)。
-2. 在 Windows 开始菜单中搜索并打开 **PowerShell**。
-3. 把下面几行一次性粘贴进去并按回车：
+- **Agent-guided setup** — works from the user's question and inspected data instead of requiring
+  GIS terminology up front.
+- **Deterministic builds** — the agent writes MapSpec 1.1; the Python engine owns loading,
+  normalization, styling, rendering, and validation.
+- **Two polished map products** — a searchable map-and-list explorer and a toggleable multilayer
+  explorer for points, lines, and polygons.
+- **Single-file delivery** — Leaflet, interface code, and business geometry are embedded in one
+  `map.html`; only online basemap tiles require a network connection.
+- **Report-ready exports** — generate 16:9 PNG plus publication PNG, SVG, and PDF from the same
+  specification.
+- **Auditable handoff** — every build records inspection results, repairs, generated IDs,
+  performance warnings, source notes, hashes, and portability.
+- **Browser-tested interaction** — search, filters, sorting, layer controls, selection, keyboard
+  behavior, and narrow-screen layouts are covered by Chromium tests.
+- **Localized output** — deterministic `en-US` and `zh-CN` interface catalogs, usage guides, and
+  public demos.
 
-```powershell
-New-Item -ItemType Directory -Force "$HOME\.agents\skills" | Out-Null
-git clone https://github.com/xlbaoxl/interactive-map-builder.git `
-  "$HOME\.agents\skills\interactive-map-builder"
-Set-Location "$HOME\.agents\skills\interactive-map-builder"
-py -m pip install .
-interactive-map-builder --help
-```
+## Live demos
 
-手动安装使用的是 Codex 官方说明中的个人 Skill 目录 `$HOME/.agents/skills`。更多背景可查看
-[OpenAI 的 Skill 文档](https://learn.chatgpt.com/docs/build-skills)。
+| Search, filter, compare | Explore independent layers |
+| --- | --- |
+| [![Parcel classification and statistics](assets/screenshots/en-US/map-list.png)](https://xlbaoxl.github.io/interactive-map-builder/en-US/map-list/) | [![Multilayer point-line-polygon explorer](assets/screenshots/en-US/multilayer.png)](https://xlbaoxl.github.io/interactive-map-builder/en-US/multilayer/) |
+| **Map + list.** Search addresses and attributes, filter categories and numeric ranges, sort records, watch KPIs update, and inspect a selected parcel. | **Multilayer.** Toggle neighborhoods, bicycle routes, and subway stations; search within a business layer; switch basemaps; inspect feature details. |
+| [Open live demo →](https://xlbaoxl.github.io/interactive-map-builder/en-US/map-list/) | [Open live demo →](https://xlbaoxl.github.io/interactive-map-builder/en-US/multilayer/) |
 
-#### 安装后这样用
+Both demos are generated by the repository's deterministic engine from fixed
+[NYC Open Data snapshots](assets/examples/SOURCES.md); they are not separate design mockups.
 
-把自己的 GeoJSON、Excel、CSV 或其他空间数据文件拖进 Codex，然后发送：
+## Quick start
 
-```text
-使用 $interactive-map-builder，把我选择的空间数据做成可以搜索和筛选的交互地图。
-```
+### 1. Install the Skill in Codex
 
-#### 复杂任务建议使用 Plan mode
-
-如果任务包含多个图层、模板还没确定、CRS 或字段含义不清，或需要比较多项设计取舍，
-建议先用 `/plan` 或 `Shift+Tab` 切换到 Plan mode。若不切换，Skill 会继续推进，并用
-下面的需求清单持续补齐信息差：
-
-```markdown
-- [x] Confirmed：用户已经确认
-- [~] Inferred：根据数据或上下文推定，可随时修改
-- [ ] Needs confirmation：构建前必须确认
-```
-
-对话语言跟随用户；地图语言根据受众单独选择 `zh-CN` 或 `en-US`。
-
-### 安装到其他 Agent
-
-将整个仓库复制到 Agent 可读取的 Skill/规则目录，让它加载 `SKILL.md`，再运行
-`python -m pip install .`。其他 Agent 应继续使用项目内置的配置和构建流程，不要临时
-重写一套 Folium 或前端实现。
-
-### 命令行用法（普通用户可以跳过）
-
-如果你熟悉命令行，可以直接运行完整的检查、配置、构建和验证流程：
-
-```powershell
-interactive-map-builder inspect `
-  assets/examples/map-list/residential.geojson `
-  assets/examples/map-list/mixed-commercial.geojson `
-  assets/examples/map-list/civic-other.geojson `
-  --output inspection.json
-interactive-map-builder init-spec inspection.json `
-  --template multilayer `
-  --locale zh-CN `
-  --output map_spec.json
-interactive-map-builder build --spec map_spec.json --out dist
-interactive-map-builder verify --dist dist
-```
-
-只有一个且没有歧义的图层时，也可以使用快捷命令：
-
-```powershell
-interactive-map-builder run data.geojson --locale zh-CN --output dist
-```
-
-### 支持的输入
-
-- GeoJSON / JSON FeatureCollection
-- GeoPackage（可指定图层）
-- 单数据集 Shapefile ZIP
-- CSV 经纬度或 WKT（必须显式 CRS）
-- Excel 经纬度或 WKT（必须显式 CRS）
-- ArcGIS FeatureServer（先下载为本地 GeoJSON）
-
-不支持：
-
-- 地址地理编码
-- 缓冲区、叠加、选址或统计推断
-- 矢量瓦片服务
-- 离线底图下载
-- 根据数值范围猜测 CRS
-
-### 固定输出
-
-每次构建都会生成：
-
-- `map.html`：内嵌 Leaflet、样式、脚本与业务 GeoJSON 的单文件地图
-- `map_spec.json`：解析默认值后的构建记录
-- `inspection.json`：输入、字段候选、CRS 与模板确认状态
-- `build_report.json`：校验、修复、警告、性能指标、哈希与可移植状态
-- `README_USAGE.md`：按地图语言生成、交付给最终使用者的简短说明
-
-静态 preset 另外生成：
-
-- `slide-16x9` → `map_slide_16x9.png`
-- `paper` → `map_paper.png`、`map_paper.svg`、`map_paper.pdf`
-
-普通 `build` 不复制源数据，输出的 `map_spec.json` 只是构建记录。需要独立重建包时使用：
-
-```powershell
-interactive-map-builder build --spec map_spec.json --out dist --bundle-sources
-```
-
-### 完整示例一：主图层 + 上下文图层
-
-检查多个输入后，显式选择主要清单图层：
-
-```powershell
-interactive-map-builder inspect sites.geojson districts.geojson `
-  --output inspection.json
-interactive-map-builder init-spec inspection.json `
-  --template map-list `
-  --primary-layer sites `
-  --output map_spec.json
-interactive-map-builder build --spec map_spec.json --out dist --bundle-sources
-interactive-map-builder verify --dist dist
-```
-
-### 完整示例二：多业务图层
-
-```powershell
-interactive-map-builder inspect districts.geojson routes.geojson places.geojson `
-  --output inspection.json
-interactive-map-builder init-spec inspection.json `
-  --template multilayer `
-  --output map_spec.json
-interactive-map-builder build --spec map_spec.json --out dist
-interactive-map-builder verify --dist dist
-```
-
-多图层中的相同要素 ID 默认互不关联。只有各图层显式配置相同语义的 `link_key` 时才会
-跨图层高亮。
-
-### 当前限制
-
-- HTML 会一次性创建全部 Leaflet 要素；报告会给出 `light`/`medium` 简化建议，但不会
-  自动切换到矢量瓦片。
-- 在线底图仍需要网络；业务几何与界面代码可离线使用。
-- 系统没有 CJK 字体时静态图继续生成，但报告会提示中文字体回退。
-- `linked_view` 是 experimental，只做已有 x/y 变量的 ID 联动，不解释象限或因果关系。
-- 多图层任务必须由用户确认 `map-list` 或 `multilayer`；工具不会从几何类型猜测业务意图。
-
-### 路线图
-
-- 用更多真实但可公开的数据包扩充行为 eval
-- 改进超大 GeoJSON 的搜索和渐进加载
-- 增加可选的视觉回归测试
-- 在保持 MapSpec 1.1 稳定的前提下评估更多静态输出 preset
-
----
-
-## English
-
-Interactive Map Builder is a map Skill for Codex and other AI assistants. Give it existing
-coordinates or spatial data; it checks the inputs and confirms uncertain choices before
-generating an interactive map plus presentation- and publication-ready figures.
-
-[Read the changelog](CHANGELOG.md).
-
-### Built-in templates and capabilities
-
-The project includes two ready-made interactive templates. These are screenshots of generated
-HTML pages, not separate design mockups. The examples use
-[NYC Open Data](assets/examples/SOURCES.md) only to demonstrate the templates' capabilities.
-The online demos need an internet connection to load the street basemap.
-
-#### Parcel classification and statistics
-
-- **Capabilities:** Search names, addresses, or attributes; filter parcel classes; review summary
-  metrics and a sortable result list; and select a parcel to inspect land use, zoning, area, FAR,
-  floors, construction year, and other attributes.
-- **Advantages:** Combines spatial distribution, class-level statistics, a browsable inventory,
-  and record details in one view. It supports rapid target selection without losing geographic
-  context and works well for parcels, facilities, projects, and candidate sites.
-
-[![Parcel classification and statistics template with class filters, sortable results, summary metrics, and parcel details](assets/screenshots/en-US/map-list.png)](https://xlbaoxl.github.io/interactive-map-builder/en-US/map-list/)
-
-[Open the parcel classification and statistics demo](https://xlbaoxl.github.io/interactive-map-builder/en-US/map-list/)
-
-#### Multilayer visualization
-
-- **Capabilities:** Combine polygon, line, and point datasets in one map; search within a selected
-  business layer; and control the display through layer toggles, categorical legends, record
-  details, and basemap switching.
-- **Advantages:** Makes cross-theme distributions and spatial relationships easier to compare
-  while reducing the need to switch between separate maps. It is suited to transport, planning,
-  public-service, environmental, and other multi-layer analysis contexts.
-
-[![Multilayer visualization template with business-layer search, layer controls, categorical legends, and record details](assets/screenshots/en-US/multilayer.png)](https://xlbaoxl.github.io/interactive-map-builder/en-US/multilayer/)
-
-[Open the multilayer visualization demo](https://xlbaoxl.github.io/interactive-map-builder/en-US/multilayer/)
-
-### Install and use it (choose either method)
-
-#### Method 1: install from a Codex task
-
-1. Open Codex and create a new task.
-2. Send this message:
+Open a new Codex task and send:
 
 ```text
 $skill-installer Install the Skill from https://github.com/xlbaoxl/interactive-map-builder and install its Python dependencies.
 ```
 
-3. Create a new task after installation. If the Skill does not appear, restart Codex once.
+Create a new task after installation. Restart Codex once only when the Skill does not appear.
 
-#### Method 2: install from Windows PowerShell
+### 2. Attach spatial data and describe the result
 
-1. Install [Git for Windows](https://git-scm.com/download/win) and
-   [Python 3.9 or newer](https://www.python.org/downloads/windows/).
-2. Search for **PowerShell** in the Windows Start menu and open it.
-3. Paste these lines and press Enter:
+```text
+Use $interactive-map-builder to turn my attached spatial data into a searchable, filterable interactive map. Use English for the map audience and export a 16:9 presentation figure.
+```
+
+The Skill first inspects the inputs, then keeps a compact requirements checklist while choices
+remain unresolved:
+
+```markdown
+- [x] Confirmed: supplied by the user or established by the data
+- [~] Inferred: proposed by the Skill and easy to revise
+- [ ] Needs confirmation: required before the build can start
+```
+
+It asks one consolidated round only for blocking choices such as CRS, template, primary layer,
+category meaning, display fields, output formats, and audience locale.
+
+<details>
+<summary><strong>Manual installation on Windows</strong></summary>
+
+Install [Git for Windows](https://git-scm.com/download/win) and
+[Python 3.9 or newer](https://www.python.org/downloads/windows/), then run:
 
 ```powershell
 New-Item -ItemType Directory -Force "$HOME\.agents\skills" | Out-Null
@@ -286,57 +103,99 @@ py -m pip install .
 interactive-map-builder --help
 ```
 
-The manual method uses the global Skill authoring directory documented by Codex:
-`$HOME/.agents/skills`. See the
-[OpenAI Skill documentation](https://learn.chatgpt.com/docs/build-skills) for details.
+</details>
 
-#### Use it after installation
+<details>
+<summary><strong>Use with Claude Code or another Agent Skills client</strong></summary>
 
-Attach a GeoJSON, Excel, CSV, or other spatial data file to Codex and send:
-
-```text
-Use $interactive-map-builder to turn my attached spatial data into a searchable, filterable interactive map.
-```
-
-#### Prefer Plan mode for complex requests
-
-For multiple layers, an undecided template, unclear CRS or field semantics, or several design
-trade-offs, switch to Plan mode with `/plan` or `Shift+Tab`. If you stay in the default mode,
-the Skill continues with a visible requirements checklist:
-
-```markdown
-- [x] Confirmed
-- [~] Inferred
-- [ ] Needs confirmation
-```
-
-The conversation follows your language. Choose the map audience separately with `en-US` or
-`zh-CN`.
-
-### Install for another agent
-
-Copy the complete repository into a Skill or rules directory that the agent can read, instruct
-it to load `SKILL.md`, and run `python -m pip install .`. Keep the project's built-in
-configuration and build workflow instead of asking the model to generate an unrelated Folium or
-frontend implementation.
-
-### Command-line workflow (optional)
-
-If you are comfortable with a terminal, run the full inspect, configure, build, and verify flow:
+Copy the complete repository into a Skill or rules directory that the client can read, let it
+load `SKILL.md`, and install the deterministic engine once:
 
 ```bash
-interactive-map-builder inspect \
-  assets/examples/map-list/residential.geojson \
-  assets/examples/map-list/mixed-commercial.geojson \
-  assets/examples/map-list/civic-other.geojson \
-  --output inspection.json
-interactive-map-builder init-spec inspection.json \
-  --template multilayer \
-  --locale en-US \
-  --output map_spec.json
-interactive-map-builder build --spec map_spec.json --out dist
-interactive-map-builder verify --dist dist
+python -m pip install .
+interactive-map-builder --help
 ```
+
+The workflow is client-neutral: inspect data, maintain the requirements checklist, write the
+canonical MapSpec, build with the packaged engine, verify, and deliver the complete `dist`
+directory.
+
+</details>
+
+## Choose the right map product
+
+| User goal | Template | Best for | Main interactions |
+| --- | --- | --- | --- |
+| Find, screen, rank, and compare records | `map-list` | Parcels, buildings, facilities, stores, projects, events, candidate sites | Search, category and numeric filters, sorting, KPI summaries, list-map linkage, detail panel |
+| Explore several independent spatial themes together | `multilayer` | Boundaries, roads, routes, facilities, environmental layers, planning context | Layer visibility, layer-specific search, point/line/polygon styling, legends, basemap switching, feature details |
+
+A `map-list` may also include context layers. With multiple inputs, the Skill never guesses the
+business intent from geometry type alone; it asks the user to confirm the template and primary
+layer.
+
+## Supported inputs
+
+| Input | Requirement |
+| --- | --- |
+| GeoJSON / JSON FeatureCollection | Geometry and CRS must be readable |
+| GeoPackage | Select a layer when the package contains more than one candidate |
+| Shapefile ZIP | One Shapefile dataset per ZIP; `.cpg`/GDAL encoding detection is preserved |
+| CSV | Longitude/latitude columns or WKT geometry plus an explicit source CRS |
+| Excel | Longitude/latitude columns or WKT geometry plus an explicit source CRS |
+| ArcGIS FeatureServer | Downloaded to a local GeoJSON snapshot before rendering |
+
+The inspection step reports feature count, geometry type, CRS, field samples, likely ID/label/
+category roles, ambiguities, and performance signals before a map is proposed.
+
+## Deliverables
+
+| File | Purpose |
+| --- | --- |
+| `map.html` | Self-contained interactive Leaflet map with embedded business geometry |
+| `map_slide_16x9.png` | Presentation-ready 1920×1080 figure when the slide preset is enabled |
+| `map_paper.png` / `.svg` / `.pdf` | Publication outputs when the paper preset is enabled |
+| `map_spec.json` | Resolved, reusable build contract |
+| `inspection.json` | Inputs, CRS, fields, candidate roles, and unresolved choices |
+| `build_report.json` | Counts, repairs, warnings, performance metrics, hashes, and portability |
+| `README_USAGE.md` | Localized handoff note for the final map recipient |
+
+A normal build keeps source paths relative to the original project and treats `map_spec.json` as
+a build record. Use `--bundle-sources` when the deliverable must rebuild independently after it
+is moved.
+
+## How it works
+
+```text
+User request + spatial files
+           │
+           ▼
+       inspect inputs
+  CRS · geometry · fields · scale
+           │
+           ▼
+  confirm unresolved intent once
+           │
+           ▼
+        MapSpec 1.1
+           │
+           ▼
+ deterministic Python engine
+ load · normalize · style · render
+           │
+           ▼
+ verify counts, files, QA hooks,
+ provenance, hashes, and browser UI
+           │
+           ▼
+  shareable HTML + report figures
+```
+
+The packaged [JSON Schema](scripts/mapcore/resources/map-spec.schema.json) is the only
+machine-readable MapSpec contract. Canonical keys use `snake_case`; unsupported fields and
+schema versions are rejected instead of being silently migrated.
+
+<details>
+<summary><strong>Command-line workflow</strong></summary>
 
 For one unambiguous layer:
 
@@ -344,89 +203,71 @@ For one unambiguous layer:
 interactive-map-builder run data.geojson --locale en-US --output dist
 ```
 
-### Supported inputs
-
-- GeoJSON / JSON FeatureCollection
-- GeoPackage, with explicit layer selection when needed
-- A single-dataset Shapefile ZIP
-- CSV longitude/latitude or WKT with an explicit CRS
-- Excel longitude/latitude or WKT with an explicit CRS
-- ArcGIS FeatureServer downloaded to local GeoJSON first
-
-Out of scope:
-
-- Address geocoding
-- Buffers, overlays, site selection, or statistical inference
-- Vector-tile services
-- Offline basemap acquisition
-- Guessing a CRS from coordinate ranges
-
-### Fixed outputs
-
-Every build writes:
-
-- `map.html`: single-file Leaflet map with embedded UI and business GeoJSON
-- `map_spec.json`: resolved build record
-- `inspection.json`: inputs, field candidates, CRS, and template-confirmation state
-- `build_report.json`: validation, repairs, warnings, performance, hashes, and portability
-- `README_USAGE.md`: localized delivery note for the end user
-
-Static presets add:
-
-- `slide-16x9` → `map_slide_16x9.png`
-- `paper` → `map_paper.png`, `map_paper.svg`, and `map_paper.pdf`
-
-A normal `build` does not copy source data. Create a portable rebuild bundle explicitly:
-
-```bash
-interactive-map-builder build --spec map_spec.json --out dist --bundle-sources
-```
-
-### Complete example 1: primary layer plus context
+For an explicit, reproducible workflow:
 
 ```bash
 interactive-map-builder inspect sites.geojson districts.geojson \
   --output inspection.json
+
 interactive-map-builder init-spec inspection.json \
   --template map-list \
   --primary-layer sites \
+  --locale en-US \
   --output map_spec.json
+
 interactive-map-builder build --spec map_spec.json --out dist --bundle-sources
 interactive-map-builder verify --dist dist
 ```
 
-### Complete example 2: mixed multilayer explorer
+For independent point, line, and polygon layers, use `--template multilayer` and omit
+`--primary-layer`.
+
+</details>
+
+## Scope
+
+Interactive Map Builder deliberately focuses on **existing spatial data → finished map product**.
+It does not currently provide:
+
+- address geocoding;
+- buffers, overlays, site-selection models, or statistical inference;
+- vector-tile services or million-feature WebGIS infrastructure;
+- offline basemap acquisition;
+- CRS guessing from coordinate ranges;
+- 3D terrain, buildings, or digital twins.
+
+For large GeoJSON payloads, the build report recommends `light` or `medium` geometry
+simplification but does not silently switch rendering engines.
+
+## Project status
+
+The project is in **v0.3 beta**. The current release line is intentionally stable around two page
+frameworks and one MapSpec contract. Near-term work is driven by real user feedback, with likely
+next steps including point clustering, proportional symbols, value-scaled line widths, polygon
+aggregation, filtered-data export, and larger-data rendering.
+
+See the [changelog](CHANGELOG.md) for completed work and the
+[product research report](product-research-report.zh-CN.md) when it is present in a development
+workspace. The repository itself keeps only durable product rules and public documentation.
+
+## Development
 
 ```bash
-interactive-map-builder inspect districts.geojson routes.geojson places.geojson \
-  --output inspection.json
-interactive-map-builder init-spec inspection.json \
-  --template multilayer \
-  --output map_spec.json
-interactive-map-builder build --spec map_spec.json --out dist
-interactive-map-builder verify --dist dist
+python -m pip install -r requirements-dev.txt
+python -m pytest -q -m "not browser"
+python -m playwright install chromium
+python -m pytest -q -m browser
 ```
 
-Equal feature IDs in different layers remain isolated. Cross-layer highlighting is enabled only
-when layers explicitly declare a semantically shared `link_key`.
+Build the localized demo site:
 
-### Current limitations
+```bash
+python scripts/build_demo_site.py --output _site
+```
 
-- Leaflet objects are still created eagerly. The report recommends `light` or `medium`
-  simplification but does not introduce vector tiles.
-- Online basemap tiles require a network connection; business geometry and UI remain embedded.
-- Static figures continue with a fallback when no CJK font is installed and record a warning.
-- `linked_view` is experimental and links existing x/y variables by ID without inventing
-  quadrant, causal, or statistical meaning.
-- Multi-layer tasks always require explicit confirmation of `map-list` versus `multilayer`.
-
-### Roadmap
-
-- Expand behavioral evals with additional redistributable real-world datasets
-- Improve search and progressive rendering for larger GeoJSON payloads
-- Add optional visual-regression coverage
-- Evaluate more static presets without expanding or fragmenting MapSpec 1.1
+The CI matrix covers Python 3.9, 3.10, and 3.12, Chromium interaction tests, wheel creation, and
+a clean out-of-repository build from the installed wheel.
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@
 
 </div>
 
-[![Interactive Map Builder parcel explorer](assets/screenshots/en-US/map-list.png)](https://xlbaoxl.github.io/interactive-map-builder/en-US/map-list/)
-
 Interactive Map Builder is a **Codex-first Agent Skill** for turning GeoJSON, GeoPackage,
 Shapefile, CSV, Excel, and ArcGIS data into shareable map products. The Skill inspects the data,
 closes only the requirements gaps the data cannot answer, writes an auditable MapSpec, builds a
@@ -89,10 +87,9 @@ It asks one consolidated round only for blocking choices such as CRS, template, 
 category meaning, display fields, output formats, and audience locale.
 
 <details>
-<summary><strong>Manual installation on Windows</strong></summary>
+<summary><strong>Manual installation</strong></summary>
 
-Install [Git for Windows](https://git-scm.com/download/win) and
-[Python 3.9 or newer](https://www.python.org/downloads/windows/), then run:
+**Windows PowerShell**
 
 ```powershell
 New-Item -ItemType Directory -Force "$HOME\.agents\skills" | Out-Null
@@ -100,6 +97,17 @@ git clone https://github.com/xlbaoxl/interactive-map-builder.git `
   "$HOME\.agents\skills\interactive-map-builder"
 Set-Location "$HOME\.agents\skills\interactive-map-builder"
 py -m pip install .
+interactive-map-builder --help
+```
+
+**macOS or Linux**
+
+```bash
+mkdir -p "$HOME/.agents/skills"
+git clone https://github.com/xlbaoxl/interactive-map-builder.git \
+  "$HOME/.agents/skills/interactive-map-builder"
+cd "$HOME/.agents/skills/interactive-map-builder"
+python3 -m pip install .
 interactive-map-builder --help
 ```
 
@@ -246,9 +254,7 @@ frameworks and one MapSpec contract. Near-term work is driven by real user feedb
 next steps including point clustering, proportional symbols, value-scaled line widths, polygon
 aggregation, filtered-data export, and larger-data rendering.
 
-See the [changelog](CHANGELOG.md) for completed work and the
-[product research report](product-research-report.zh-CN.md) when it is present in a development
-workspace. The repository itself keeps only durable product rules and public documentation.
+See the [changelog](CHANGELOG.md) for completed work.
 
 ## Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,8 +15,6 @@
 
 </div>
 
-[![Interactive Map Builder 地块查询与统计地图](assets/screenshots/zh-CN/map-list.png)](https://xlbaoxl.github.io/interactive-map-builder/zh-CN/map-list/)
-
 Interactive Map Builder 是一个 **以 Codex 为主要使用场景、兼容 Agent Skills 工作流**的地图
 Skill。把 GeoJSON、GeoPackage、Shapefile、CSV、Excel 或 ArcGIS 数据交给它，它会先检查
 数据，只询问数据本身无法回答的选项，再写入可审计的 MapSpec，生成单文件 Leaflet 地图，
@@ -85,10 +83,9 @@ Skill 会先检查数据，并在仍有不确定项时维护一份简短需求�
 输出格式和地图受众语言。
 
 <details>
-<summary><strong>Windows 手动安装</strong></summary>
+<summary><strong>手动安装</strong></summary>
 
-先安装 [Git for Windows](https://git-scm.com/download/win) 和
-[Python 3.9 或更高版本](https://www.python.org/downloads/windows/)，然后在 PowerShell 中运行：
+**Windows PowerShell**
 
 ```powershell
 New-Item -ItemType Directory -Force "$HOME\.agents\skills" | Out-Null
@@ -96,6 +93,17 @@ git clone https://github.com/xlbaoxl/interactive-map-builder.git `
   "$HOME\.agents\skills\interactive-map-builder"
 Set-Location "$HOME\.agents\skills\interactive-map-builder"
 py -m pip install .
+interactive-map-builder --help
+```
+
+**macOS 或 Linux**
+
+```bash
+mkdir -p "$HOME/.agents/skills"
+git clone https://github.com/xlbaoxl/interactive-map-builder.git \
+  "$HOME/.agents/skills/interactive-map-builder"
+cd "$HOME/.agents/skills/interactive-map-builder"
+python3 -m pip install .
 interactive-map-builder --help
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,260 @@
+<div align="center">
+
+# Interactive Map Builder
+
+**把已有空间数据交给 AI Agent，得到漂亮、可验证、可直接交付的地图产品。**
+
+[![CI](https://github.com/xlbaoxl/interactive-map-builder/actions/workflows/ci.yml/badge.svg)](https://github.com/xlbaoxl/interactive-map-builder/actions/workflows/ci.yml)
+[![Python 3.9+](https://img.shields.io/badge/Python-3.9%2B-3776AB?logo=python&logoColor=white)](pyproject.toml)
+[![MapSpec 1.1](https://img.shields.io/badge/MapSpec-1.1-0f766e)](references/map-spec.md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-2ea44f.svg)](LICENSE)
+
+[在线演示](https://xlbaoxl.github.io/interactive-map-builder/zh-CN/) ·
+[English](README.md) ·
+[更新日志](CHANGELOG.md)
+
+</div>
+
+[![Interactive Map Builder 地块查询与统计地图](assets/screenshots/zh-CN/map-list.png)](https://xlbaoxl.github.io/interactive-map-builder/zh-CN/map-list/)
+
+Interactive Map Builder 是一个 **以 Codex 为主要使用场景、兼容 Agent Skills 工作流**的地图
+Skill。把 GeoJSON、GeoPackage、Shapefile、CSV、Excel 或 ArcGIS 数据交给它，它会先检查
+数据，只询问数据本身无法回答的选项，再写入可审计的 MapSpec，生成单文件 Leaflet 地图，
+检查交互结果，并同步导出适合 PPT 和论文的静态图。
+
+```text
+空间数据 → 检查 → 集中确认 → MapSpec → 构建 → 浏览器验证 → HTML + PNG/SVG/PDF
+```
+
+不需要前端工程，不需要手写 Folium 页面，也不会隐藏数据清洗过程。
+
+## 核心特点
+
+- **用自然语言配置地图**：用户只需说明想回答什么问题，不必先掌握分级设色、图层控制等
+  GIS 术语。
+- **确定性构建**：Agent 负责理解需求和编写 MapSpec，Python 引擎统一负责读取、清洗、
+  样式、渲染和校验，避免每次临时生成一套不同代码。
+- **两种成熟地图产品**：可搜索筛选的“地图＋清单”，以及可独立开关点、线、面数据的
+  “多图层地图”。
+- **单文件交付**：Leaflet、界面逻辑和业务几何都嵌入 `map.html`；只有在线街道底图需要网络。
+- **汇报与论文输出**：同一份配置可生成 16:9 PNG，以及论文用 PNG、SVG 和 PDF。
+- **完整构建记录**：自动保存数据检查、几何修复、生成 ID、性能提示、数据来源、文件哈希
+  和可移植状态。
+- **真实浏览器测试**：搜索、筛选、排序、图层开关、对象选择、键盘操作和窄屏布局均有
+  Chromium 测试。
+- **中英文地图界面**：内置稳定的 `zh-CN` 和 `en-US` 文案、ARIA 标签、交付说明和公开演示。
+
+## 在线演示
+
+| 搜索、筛选和比较对象 | 联合查看多个空间主题 |
+| --- | --- |
+| [![地块分类统计地图](assets/screenshots/zh-CN/map-list.png)](https://xlbaoxl.github.io/interactive-map-builder/zh-CN/map-list/) | [![点线面多图层地图](assets/screenshots/zh-CN/multilayer.png)](https://xlbaoxl.github.io/interactive-map-builder/zh-CN/multilayer/) |
+| **地图＋清单。** 搜索地址和属性，筛选类别与数值范围，排序记录，观察统计指标变化，并查看选中地块的完整信息。 | **多图层。** 独立开关邻里分区、自行车线路和地铁站，按业务图层搜索，切换底图并查看对象详情。 |
+| [打开交互演示 →](https://xlbaoxl.github.io/interactive-map-builder/zh-CN/map-list/) | [打开交互演示 →](https://xlbaoxl.github.io/interactive-map-builder/zh-CN/multilayer/) |
+
+两个演示都由仓库中的确定性引擎根据固定的
+[NYC Open Data 数据快照](assets/examples/SOURCES.md)生成，不是另外制作的设计稿。
+
+## 快速开始
+
+### 1. 在 Codex 中安装 Skill
+
+打开一个新的 Codex 任务，发送：
+
+```text
+$skill-installer 请从 https://github.com/xlbaoxl/interactive-map-builder 安装这个 Skill，并安装它需要的 Python 依赖。
+```
+
+安装完成后新建任务。如果新任务中没有出现该 Skill，再重启一次 Codex。
+
+### 2. 上传数据并描述目标
+
+```text
+使用 $interactive-map-builder，把我上传的空间数据做成可以搜索和筛选的中文交互地图，同时导出一张 16:9 汇报图。
+```
+
+Skill 会先检查数据，并在仍有不确定项时维护一份简短需求清单：
+
+```markdown
+- [x] Confirmed：用户已明确，或数据已经证明
+- [~] Inferred：Skill 根据数据提出的建议，可以修改
+- [ ] Needs confirmation：构建前必须确认
+```
+
+它只会集中询问一次真正影响结果的内容，例如 CRS、模板、主图层、分类含义、展示字段、
+输出格式和地图受众语言。
+
+<details>
+<summary><strong>Windows 手动安装</strong></summary>
+
+先安装 [Git for Windows](https://git-scm.com/download/win) 和
+[Python 3.9 或更高版本](https://www.python.org/downloads/windows/)，然后在 PowerShell 中运行：
+
+```powershell
+New-Item -ItemType Directory -Force "$HOME\.agents\skills" | Out-Null
+git clone https://github.com/xlbaoxl/interactive-map-builder.git `
+  "$HOME\.agents\skills\interactive-map-builder"
+Set-Location "$HOME\.agents\skills\interactive-map-builder"
+py -m pip install .
+interactive-map-builder --help
+```
+
+</details>
+
+<details>
+<summary><strong>在 Claude Code 或其他 Agent Skills 客户端中使用</strong></summary>
+
+把完整仓库复制到客户端能够读取的 Skill 或规则目录，让它加载 `SKILL.md`，然后安装一次
+确定性引擎：
+
+```bash
+python -m pip install .
+interactive-map-builder --help
+```
+
+工作流不依赖特定客户端界面：检查数据、维护需求清单、写入当前 MapSpec、使用仓库内引擎
+构建、验证并交付完整 `dist` 目录。
+
+</details>
+
+## 选择哪种地图
+
+| 用户目标 | 底层模板 | 适用数据 | 主要交互 |
+| --- | --- | --- | --- |
+| 查找、筛选、排序和比较每条记录 | `map-list` | 地块、建筑、设施、门店、项目、事件、候选地点 | 搜索、分类与数值筛选、排序、动态统计、地图清单联动、详情面板 |
+| 同时查看多个相互独立的空间主题 | `multilayer` | 边界、道路、线路、设施、环境和规划背景 | 图层开关、分图层搜索、点线面样式、图例、底图切换、对象详情 |
+
+`map-list` 也可以附带行政区或道路等背景图层。存在多个输入时，Skill 不会仅凭几何类型
+猜测业务意图，而会要求用户确认模板和主图层。
+
+## 支持的数据
+
+| 输入格式 | 要求 |
+| --- | --- |
+| GeoJSON / JSON FeatureCollection | 几何和 CRS 可正常读取 |
+| GeoPackage | 包含多个候选图层时需要明确选择 |
+| Shapefile ZIP | 每个 ZIP 只放一套 Shapefile；保留 `.cpg`/GDAL 编码识别 |
+| CSV | 具有经纬度字段或 WKT，并明确源 CRS |
+| Excel | 具有经纬度字段或 WKT，并明确源 CRS |
+| ArcGIS FeatureServer | 先下载为本地 GeoJSON 快照，再进入地图构建 |
+
+在推荐地图之前，检查阶段会输出要素数量、几何类型、CRS、字段样例、候选 ID/名称/分类
+字段、歧义和性能提示。
+
+## 交付内容
+
+| 文件 | 用途 |
+| --- | --- |
+| `map.html` | 内嵌业务几何和全部界面逻辑的单文件 Leaflet 地图 |
+| `map_slide_16x9.png` | 启用汇报 preset 时生成的 1920×1080 图片 |
+| `map_paper.png` / `.svg` / `.pdf` | 启用论文 preset 时生成的出版图件 |
+| `map_spec.json` | 解析后的可复用构建契约 |
+| `inspection.json` | 输入、CRS、字段候选和待确认项 |
+| `build_report.json` | 数量、修复、警告、性能、哈希和可移植状态 |
+| `README_USAGE.md` | 面向地图接收者的本地化使用说明 |
+
+普通构建不会复制源数据，`map_spec.json` 只作为原项目中的构建记录。需要把整个结果移动到
+其他电脑后独立重建时，使用 `--bundle-sources`。
+
+## 工作原理
+
+```text
+用户需求 + 空间文件
+          │
+          ▼
+       检查数据
+ CRS · 几何 · 字段 · 数据规模
+          │
+          ▼
+  一次性确认无法自动判断的选项
+          │
+          ▼
+       MapSpec 1.1
+          │
+          ▼
+     确定性 Python 引擎
+ 读取 · 规范化 · 配色 · 渲染
+          │
+          ▼
+ 校验数量、文件、QA 接口、
+ 数据来源、哈希和浏览器交互
+          │
+          ▼
+ 可分享 HTML + 汇报与论文图件
+```
+
+打包的 [JSON Schema](scripts/mapcore/resources/map-spec.schema.json) 是 MapSpec 唯一的机器契约。
+配置只接受规范的 `snake_case` 字段；不支持的字段和 Schema 版本会被直接拒绝，不会静默迁移。
+
+<details>
+<summary><strong>命令行工作流</strong></summary>
+
+只有一个且没有歧义的图层时：
+
+```bash
+interactive-map-builder run data.geojson --locale zh-CN --output dist
+```
+
+需要显式控制和保存配置时：
+
+```bash
+interactive-map-builder inspect sites.geojson districts.geojson \
+  --output inspection.json
+
+interactive-map-builder init-spec inspection.json \
+  --template map-list \
+  --primary-layer sites \
+  --locale zh-CN \
+  --output map_spec.json
+
+interactive-map-builder build --spec map_spec.json --out dist --bundle-sources
+interactive-map-builder verify --dist dist
+```
+
+独立的点、线、面业务图层使用 `--template multilayer`，不填写 `--primary-layer`。
+
+</details>
+
+## 能力边界
+
+Interactive Map Builder 专注于 **已有空间数据 → 可交付地图成品**，目前不负责：
+
+- 把地址批量转换成坐标；
+- 缓冲区、叠加、选址模型和统计推断；
+- 矢量瓦片服务和千万级要素 WebGIS；
+- 离线底图下载；
+- 根据坐标数值猜测 CRS；
+- 三维地形、建筑和数字孪生。
+
+对于较大的 GeoJSON，构建报告会建议使用 `light` 或 `medium` 几何简化，但不会在用户不知情
+时切换渲染引擎。
+
+## 项目状态
+
+项目当前处于 **v0.3 Beta**。这一阶段稳定维护两套页面框架和一份 MapSpec 契约，不继续盲目
+增加页面模板。下一步由真实用户反馈决定，候选方向包括点聚合、比例圆点、按数值变化的线宽、
+区域汇总、导出当前筛选结果和更大数据量的渲染。
+
+已经完成的变化见[更新日志](CHANGELOG.md)。
+
+## 开发与测试
+
+```bash
+python -m pip install -r requirements-dev.txt
+python -m pytest -q -m "not browser"
+python -m playwright install chromium
+python -m pytest -q -m browser
+```
+
+构建中英文 GitHub Pages 演示：
+
+```bash
+python scripts/build_demo_site.py --output _site
+```
+
+CI 覆盖 Python 3.9、3.10、3.12、Chromium 交互测试、wheel 构建，以及在仓库之外安装 wheel 后
+重新生成并验证地图。
+
+## 许可证
+
+[MIT](LICENSE)

--- a/tests/test_demo_site.py
+++ b/tests/test_demo_site.py
@@ -63,22 +63,30 @@ def test_demo_site_builds_atlas_landing_without_changing_source_assets(tmp_path:
     assert original_assets == {path: path.read_bytes() for path in source_paths}
 
 
-def test_readme_links_to_both_interactive_demos() -> None:
-    readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    for locale in ("en-US", "zh-CN"):
-        assert f"{PAGES_URL}/{locale}/map-list/" in readme
-        assert f"{PAGES_URL}/{locale}/multilayer/" in readme
+def test_localized_readmes_link_to_their_interactive_demos() -> None:
+    readme_en = (ROOT / "README.md").read_text(encoding="utf-8")
+    readme_zh = (ROOT / "README.zh-CN.md").read_text(encoding="utf-8")
+
+    assert f"{PAGES_URL}/en-US/map-list/" in readme_en
+    assert f"{PAGES_URL}/en-US/multilayer/" in readme_en
+    assert f"{PAGES_URL}/zh-CN/map-list/" in readme_zh
+    assert f"{PAGES_URL}/zh-CN/multilayer/" in readme_zh
+
     for expected in (
-        "#### 地块分类统计",
-        "#### 多图层可视化",
-        "**功能：**",
-        "**优势：**",
-        "#### Parcel classification and statistics",
-        "#### Multilayer visualization",
-        "**Capabilities:**",
-        "**Advantages:**",
+        "## Live demos",
+        "**Map + list.**",
+        "**Multilayer.**",
+        "## Quick start",
     ):
-        assert expected in readme
+        assert expected in readme_en
+
+    for expected in (
+        "## 在线演示",
+        "**地图＋清单。**",
+        "**多图层。**",
+        "## 快速开始",
+    ):
+        assert expected in readme_zh
 
 
 def test_pages_workflow_uses_official_actions_and_permissions() -> None:

--- a/tests/test_language_policy.py
+++ b/tests/test_language_policy.py
@@ -8,6 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 HAN = re.compile(r"[\u3400-\u9fff\uf900-\ufaff]")
 ALLOWED_FILES = {
     ROOT / "README.md",
+    ROOT / "README.zh-CN.md",
     ROOT / "CHANGELOG.md",
     ROOT / "scripts" / "mapcore" / "resources" / "locales" / "zh-CN.json",
 }

--- a/tests/test_skill_structure.py
+++ b/tests/test_skill_structure.py
@@ -26,23 +26,34 @@ def test_openai_interface_mentions_skill():
     assert "$interactive-map-builder" in data["interface"]["default_prompt"]
 
 
-def test_behavior_evals_and_bilingual_readme_are_present():
+def test_behavior_evals_and_localized_readmes_are_present():
     evals = yaml.safe_load((ROOT / "evals" / "cases.yaml").read_text(encoding="utf-8"))
     assert evals["version"] == 1
     assert len(evals["cases"]) == 10
     invocations = {case["expected"]["invocation"] for case in evals["cases"]}
     assert invocations == {"trigger", "do_not_use"}
 
-    readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    assert "## 中文" in readme
-    assert "## English" in readme
-    for locale in ("en-US", "zh-CN"):
-        assert f"assets/screenshots/{locale}/map-list.png" in readme
-        assert f"assets/screenshots/{locale}/multilayer.png" in readme
-    assert "$skill-installer" in readme
-    assert "$HOME\\.agents\\skills" in readme
-    assert "三分钟开始" not in readme
-    assert "Three-minute quick start" not in readme
+    readme_en = (ROOT / "README.md").read_text(encoding="utf-8")
+    readme_zh = (ROOT / "README.zh-CN.md").read_text(encoding="utf-8")
+
+    assert "[中文说明](README.zh-CN.md)" in readme_en
+    assert "[English](README.md)" in readme_zh
+    assert "assets/screenshots/en-US/map-list.png" in readme_en
+    assert "assets/screenshots/en-US/multilayer.png" in readme_en
+    assert "assets/screenshots/zh-CN/map-list.png" in readme_zh
+    assert "assets/screenshots/zh-CN/multilayer.png" in readme_zh
+
+    for readme in (readme_en, readme_zh):
+        assert "$skill-installer" in readme
+        assert "$HOME\\.agents\\skills" in readme
+        assert "Plan mode" not in readme
+        assert "/plan" not in readme
+        assert "Shift+Tab" not in readme
+
+    assert "## Quick start" in readme_en
+    assert "## 快速开始" in readme_zh
+    assert "## 中文" not in readme_en
+    assert "## English" not in readme_en
 
 
 def test_readme_example_provenance_is_documented():


### PR DESCRIPTION
## Summary

- replace the duplicated bilingual README with a concise English main README and a dedicated Chinese README
- lead with the product promise, live generated demos, highlights, and a two-step Codex quick start
- document map-product selection, supported inputs, deliverables, the deterministic build pipeline, scope, status, and development commands
- remove stale Plan mode and client-specific shortcut guidance so the README matches the current cross-agent Skill workflow
- update README contract tests and the language policy

## Why

The previous README mixed product marketing, installation instructions, CLI reference, limitations, and two complete languages in one long page. The new structure follows strong open-source README patterns: a clear one-line value proposition, immediate visual proof, highlights, quick start, progressive disclosure, and separate translations.

## Validation

GitHub Actions should run the full Python, browser, and clean-wheel matrix.