### PR TITLE
v0.5: add browser-persistent Saved Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,27 @@ first release with an automated tag, distribution assets, and GitHub Release wor
 
 ## [Unreleased] / 未发布
 
+## [0.5.0] - 2026-08-11
+
+### Added / 新增
+
+- 两种现有地图产品新增 Saved Views 视角栏：可从顶部保存最多 8 个命名视角，只记录地图中心点
+  与缩放级别，并可在固定“总览”和各重点场地之间一键返回。
+  Added Saved Views to both existing map products: save up to eight named center-and-zoom views
+  from the header and return to them with one click alongside a fixed Overview entry.
+- 保存视角使用当前浏览器的本地存储，在同一地图刷新或重新打开后继续存在，并提供重命名、删除
+  和中英文界面；视角状态不会写回 HTML 或 MapSpec，也不会随地图文件发送到其他浏览器。
+  Persisted saved views in browser-local storage for the same generated map, with rename/delete and
+  bilingual controls; view state does not mutate HTML or MapSpec and does not travel with the map
+  file to another browser.
+
+### Changed / 变更
+
+- 包版本更新为 0.5.0；MapSpec 继续保持 1.1，仍复用 `map-list` 与 `multilayer` 两种模板，不新增
+  运行依赖或通用数据分析能力。
+  Updated the package to 0.5.0 while retaining MapSpec 1.1, the two existing templates, the current
+  dependency footprint, and the existing boundary against generic analytical modeling.
+
 ## [0.4.4] - 2026-07-28
 
 ### Added / 新增

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ No frontend build system, no hand-written Folium page, and no hidden cleanup.
   designer's work.
 - **Two polished map products** — a searchable map-and-list explorer and a toggleable multilayer
   explorer for points, lines, and polygons.
+- **Saved Views in v0.5.0** — save up to eight named map centers and zoom levels in the browser,
+  then jump between Overview and key sites during analysis or presentation without changing MapSpec.
 - **Portable local delivery** — Leaflet, interface code, and business geometry are embedded in one
   `map.html`; only online basemap tiles require a network connection.
 - **Opt-in report exports** — generate 16:9 PNG or publication PNG/SVG/PDF from the same visual
@@ -399,10 +401,10 @@ but does not silently switch rendering engines.
 
 ## Project status
 
-The current stable release is **v0.4.4**. This stabilization release makes delivery transactional,
-adds a managed-file manifest and strict verification, moves ordinary release preflight to cached
-check-only behavior, limits ZIP extraction resources, and restricts manual Release runs to repairing
-an existing tag. MapSpec remains 1.1 and cartographic behavior is unchanged.
+The **v0.5.0** release adds browser-persistent Saved Views to both existing map products: save up to
+eight named center-and-zoom positions, return to Overview or key sites with one click, and manage
+those views without changing MapSpec or the delivered HTML file. MapSpec remains 1.1 and the two
+existing template families remain unchanged.
 
 See the [changelog](CHANGELOG.md) for completed work.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -353,7 +353,7 @@ interactive-map-builder build --spec map_spec.json --out dist --bundle-sources
 interactive-map-builder verify --dist dist
 ```
 
-独立的点、线、面业务图层使用 `--template multilayer`，不填写 `--primary_layer`。
+独立的点、线、面业务图层使用 `--template multilayer`，不填写 `--primary-layer`。
 
 </details>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,6 +42,8 @@ GeoPackage、Shapefile、CSV、Excel 或 ArcGIS 数据，只询问真正影响�
   角色进行解析，让第一版总体协调，同时不替代设计师继续打磨。
 - **两种成熟地图产品**：可搜索筛选的“地图＋清单”，以及可独立开关点、线、面数据的
   “多图层地图”。
+- **v0.5.0 保存视角**：可在浏览器中保存最多 8 个命名的地图中心点与缩放级别，并在“总览”和
+  重点场地之间一键切换；视角状态不写入 MapSpec。
 - **本地单文件交付**：Leaflet、界面逻辑和业务几何都嵌入 `map.html`；只有在线底图需要网络。
 - **按需生成静态图**：只有用户明确要求时，才从同一视觉方案生成 16:9 PNG 或论文用
   PNG、SVG 和 PDF。
@@ -351,7 +353,7 @@ interactive-map-builder build --spec map_spec.json --out dist --bundle-sources
 interactive-map-builder verify --dist dist
 ```
 
-独立的点、线、面业务图层使用 `--template multilayer`，不填写 `--primary-layer`。
+独立的点、线、面业务图层使用 `--template multilayer`，不填写 `--primary_layer`。
 
 </details>
 
@@ -373,9 +375,9 @@ Interactive Map Builder 专注于**已有空间数据 → 可交付地图成品*
 
 ## 项目状态
 
-当前稳定版本为 **v0.4.4**。本次稳定化更新引入事务性交付、受管文件清单和严格验证；普通任务
-改为带缓存、只检查不修改的版本预检；ZIP 解压加入资源上限；手动 Release 只允许修复既有标签。
-MapSpec 继续保持 1.1，制图范围与 Atlas Studio Light 视觉行为不变。
+**v0.5.0** 新增浏览器本地持久化的保存视角功能，两种现有地图产品都可以保存最多 8 个命名的
+Center + Zoom 视角，在“总览”和重点场地之间一键切换，并支持重命名和删除。该状态不会修改
+MapSpec 或交付的 HTML 文件；MapSpec 继续保持 1.1，两种既有模板不变。
 
 已经完成的变化见[更新日志](CHANGELOG.md)。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "interactive-map-builder"
-version = "0.4.4"
+version = "0.5.0"
 description = "Turn existing spatial data into verified interactive maps and report-ready figures with AI agents."
 requires-python = ">=3.9"
 license = "MIT"

--- a/scripts/mapcore/render_html.py
+++ b/scripts/mapcore/render_html.py
@@ -213,7 +213,9 @@ def _template_assets(template_name: str) -> Dict[str, str]:
     """Return shared assets plus narrowly scoped template enhancements."""
 
     javascript = read_resource_text("templates", "shared.js")
+    javascript += "\n" + read_resource_text("templates", "saved-views.js")
     css = read_resource_text("templates", "atlas-studio-light.css")
+    css += "\n" + read_resource_text("templates", "saved-views.css")
     if template_name == "multilayer":
         javascript += "\n" + read_resource_text(
             "templates", "multilayer-enhancements.js"

--- a/scripts/mapcore/resources/locales/en-US.json
+++ b/scripts/mapcore/resources/locales/en-US.json
@@ -62,6 +62,24 @@
     "no_basemap": "No basemap",
     "basemap_unavailable": "Basemap tiles could not be loaded. Showing no basemap."
   },
+  "saved_views": {
+    "region": "Saved views",
+    "overview": "Overview",
+    "save": "+ Save view",
+    "manage": "Manage saved views",
+    "close": "Close",
+    "defaultName": "View",
+    "empty": "No saved views yet.",
+    "rename": "Rename",
+    "remove": "Delete",
+    "renamePrompt": "Rename view",
+    "deleteConfirm": "Delete “{name}”?",
+    "goTo": "Go to {name}",
+    "limit": "You can save up to 8 views.",
+    "saveHint": "Save the current map center and zoom.",
+    "invalidName": "Use a unique, non-empty view name.",
+    "savePrompt": "Save current view as"
+  },
   "map_list": {
     "eyebrow": "ATLAS DATA EXPLORER",
     "collapse": "Collapse list",

--- a/scripts/mapcore/resources/locales/zh-CN.json
+++ b/scripts/mapcore/resources/locales/zh-CN.json
@@ -52,6 +52,24 @@
     "no_basemap": "无底图",
     "basemap_unavailable": "在线底图加载失败，已切换为无底图。"
   },
+  "saved_views": {
+    "region": "保存视角",
+    "overview": "总览",
+    "save": "+ 保存视角",
+    "manage": "管理视角",
+    "close": "关闭",
+    "defaultName": "视角",
+    "empty": "暂无保存视角。",
+    "rename": "重命名",
+    "remove": "删除",
+    "renamePrompt": "重命名视角",
+    "deleteConfirm": "删除“{name}”吗？",
+    "goTo": "前往 {name}",
+    "limit": "最多保存 8 个视角。",
+    "saveHint": "保存当前地图中心和缩放级别。",
+    "invalidName": "请输入唯一且非空的视角名称。",
+    "savePrompt": "将当前视角保存为"
+  },
   "map_list": {
     "eyebrow": "ATLAS 数据浏览器",
     "collapse": "收起清单",

--- a/scripts/mapcore/resources/templates/saved-views.css
+++ b/scripts/mapcore/resources/templates/saved-views.css
@@ -1,0 +1,226 @@
+.imb-saved-views {
+  display: flex;
+  min-width: 180px;
+  max-width: min(48vw, 620px);
+  flex: 0 1 620px;
+  align-items: center;
+  justify-content: center;
+}
+
+.imb-saved-view-strip {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  overflow-x: auto;
+  padding: 2px;
+  scrollbar-width: none;
+}
+
+.imb-saved-view-strip::-webkit-scrollbar {
+  display: none;
+}
+
+.imb-saved-view-list {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.imb-saved-view-chip,
+.imb-saved-view-add,
+.imb-saved-view-manage {
+  min-height: 30px;
+  flex: 0 0 auto;
+  border: 1px solid var(--imb-line);
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: none;
+  transition: border-color 140ms ease, background 140ms ease, color 140ms ease,
+    transform 140ms ease;
+}
+
+.imb-saved-view-chip,
+.imb-saved-view-add {
+  padding: 5px 10px;
+  border-radius: 999px;
+  color: var(--imb-ink-soft);
+  font-size: 0.72rem;
+  font-weight: 720;
+  white-space: nowrap;
+}
+
+.imb-saved-view-chip:hover,
+.imb-saved-view-add:hover,
+.imb-saved-view-manage:hover {
+  border-color: rgba(15, 118, 110, 0.38);
+  background: #ffffff;
+}
+
+.imb-saved-view-chip:active,
+.imb-saved-view-add:active,
+.imb-saved-view-manage:active {
+  transform: translateY(1px);
+}
+
+.imb-saved-view-chip.is-active {
+  color: var(--imb-accent-dark);
+  border-color: rgba(15, 118, 110, 0.28);
+  background: var(--imb-accent-soft);
+}
+
+.imb-saved-view-add {
+  color: var(--imb-accent-dark);
+  border-style: dashed;
+  background: transparent;
+}
+
+.imb-saved-view-add:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.imb-saved-view-manage {
+  display: inline-grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  padding: 0;
+  border-radius: 50%;
+  color: var(--imb-muted);
+  font-size: 0.95rem;
+  font-weight: 800;
+}
+
+.imb-saved-view-dialog {
+  width: min(520px, calc(100vw - 28px));
+  max-height: min(70vh, 560px);
+  padding: 0;
+  border: 1px solid var(--imb-line-strong);
+  border-radius: 16px;
+  background: var(--imb-panel-solid);
+  box-shadow: var(--imb-shadow-md);
+}
+
+.imb-saved-view-dialog::backdrop {
+  background: rgba(23, 35, 38, 0.28);
+  backdrop-filter: blur(2px);
+}
+
+.imb-saved-view-dialog-card {
+  display: grid;
+  min-width: 0;
+}
+
+.imb-saved-view-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  gap: 12px;
+  border-bottom: 1px solid var(--imb-line);
+}
+
+.imb-saved-view-dialog-header h2 {
+  margin: 0;
+  font-size: 0.98rem;
+}
+
+.imb-saved-view-dialog-close {
+  display: inline-grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--imb-line);
+  border-radius: 10px;
+  background: #ffffff;
+  font-size: 1rem;
+}
+
+.imb-saved-view-dialog-list {
+  display: grid;
+  max-height: min(56vh, 440px);
+  overflow-y: auto;
+  padding: 8px;
+  gap: 4px;
+}
+
+.imb-saved-view-dialog-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px;
+  gap: 10px;
+  border-radius: 10px;
+}
+
+.imb-saved-view-dialog-row:hover {
+  background: #f7faf9;
+}
+
+.imb-saved-view-dialog-name {
+  min-width: 0;
+  overflow: hidden;
+  flex: 1 1 auto;
+  font-size: 0.8rem;
+  font-weight: 720;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.imb-saved-view-dialog-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+}
+
+.imb-saved-view-dialog-actions .imb-button {
+  min-height: 30px;
+  padding: 5px 9px;
+  font-size: 0.7rem;
+}
+
+.imb-saved-view-delete {
+  color: var(--imb-danger);
+  border-color: rgba(180, 35, 24, 0.18);
+  background: rgba(180, 35, 24, 0.03);
+}
+
+.imb-saved-view-empty {
+  margin: 0;
+  padding: 18px 12px;
+  color: var(--imb-muted);
+  font-size: 0.78rem;
+  text-align: center;
+}
+
+@media (max-width: 1080px) {
+  .imb-saved-views {
+    max-width: 38vw;
+    flex-basis: 440px;
+  }
+}
+
+@media (max-width: 760px) {
+  .imb-saved-views {
+    min-width: 120px;
+    max-width: 42vw;
+    flex-basis: 42vw;
+  }
+
+  .imb-saved-view-chip,
+  .imb-saved-view-add {
+    padding-inline: 8px;
+    font-size: 0.68rem;
+  }
+
+  .imb-saved-view-dialog-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/scripts/mapcore/resources/templates/saved-views.js
+++ b/scripts/mapcore/resources/templates/saved-views.js
@@ -25,25 +25,7 @@
   }
 
   function labels(payload) {
-    var zh = IMB.text(document.documentElement.lang).toLocaleLowerCase().indexOf("zh") === 0;
-    var fallback = zh ? {
-      region: "\u4fdd\u5b58\u89c6\u89d2",
-      overview: "\u603b\u89c8",
-      save: "+ \u4fdd\u5b58\u89c6\u89d2",
-      manage: "\u7ba1\u7406\u89c6\u89d2",
-      close: "\u5173\u95ed",
-      defaultName: "\u89c6\u89d2",
-      empty: "\u6682\u65e0\u4fdd\u5b58\u89c6\u89d2\u3002",
-      rename: "\u91cd\u547d\u540d",
-      remove: "\u5220\u9664",
-      renamePrompt: "\u91cd\u547d\u540d\u89c6\u89d2",
-      deleteConfirm: "\u5220\u9664\u201c{name}\u201d\u5417\uff1f",
-      goTo: "\u524d\u5f80 {name}",
-      limit: "\u6700\u591a\u4fdd\u5b58 8 \u4e2a\u89c6\u89d2\u3002",
-      saveHint: "\u4fdd\u5b58\u5f53\u524d\u5730\u56fe\u4e2d\u5fc3\u548c\u7f29\u653e\u7ea7\u522b\u3002",
-      invalidName: "\u8bf7\u8f93\u5165\u552f\u4e00\u4e14\u975e\u7a7a\u7684\u89c6\u89d2\u540d\u79f0\u3002",
-      savePrompt: "\u5c06\u5f53\u524d\u89c6\u89d2\u4fdd\u5b58\u4e3a"
-    } : {
+    var fallback = {
       region: "Saved views",
       overview: "Overview",
       save: "+ Save view",
@@ -64,10 +46,11 @@
     var configured = payload.catalog && payload.catalog.saved_views
       ? payload.catalog.saved_views
       : {};
-    Object.keys(configured).forEach(function (key) {
-      fallback[key] = IMB.text(configured[key]);
+    var resolved = {};
+    Object.keys(fallback).forEach(function (key) {
+      resolved[key] = IMB.text(configured[key] || fallback[key]);
     });
-    return fallback;
+    return resolved;
   }
 
   function storageFor(payload) {

--- a/scripts/mapcore/resources/templates/saved-views.js
+++ b/scripts/mapcore/resources/templates/saved-views.js
@@ -27,22 +27,22 @@
   function labels(payload) {
     var zh = IMB.text(document.documentElement.lang).toLocaleLowerCase().indexOf("zh") === 0;
     var fallback = zh ? {
-      region: "保存视角",
-      overview: "总览",
-      save: "+ 保存视角",
-      manage: "管理视角",
-      close: "关闭",
-      defaultName: "视角",
-      empty: "暂无保存视角。",
-      rename: "重命名",
-      remove: "删除",
-      renamePrompt: "重命名视角",
-      deleteConfirm: "删除“{name}”吗？",
-      goTo: "前往 {name}",
-      limit: "最多保存 8 个视角。",
-      saveHint: "保存当前地图中心和缩放级别。",
-      invalidName: "请输入唯一且非空的视角名称。",
-      savePrompt: "将当前视角保存为"
+      region: "\u4fdd\u5b58\u89c6\u89d2",
+      overview: "\u603b\u89c8",
+      save: "+ \u4fdd\u5b58\u89c6\u89d2",
+      manage: "\u7ba1\u7406\u89c6\u89d2",
+      close: "\u5173\u95ed",
+      defaultName: "\u89c6\u89d2",
+      empty: "\u6682\u65e0\u4fdd\u5b58\u89c6\u89d2\u3002",
+      rename: "\u91cd\u547d\u540d",
+      remove: "\u5220\u9664",
+      renamePrompt: "\u91cd\u547d\u540d\u89c6\u89d2",
+      deleteConfirm: "\u5220\u9664\u201c{name}\u201d\u5417\uff1f",
+      goTo: "\u524d\u5f80 {name}",
+      limit: "\u6700\u591a\u4fdd\u5b58 8 \u4e2a\u89c6\u89d2\u3002",
+      saveHint: "\u4fdd\u5b58\u5f53\u524d\u5730\u56fe\u4e2d\u5fc3\u548c\u7f29\u653e\u7ea7\u522b\u3002",
+      invalidName: "\u8bf7\u8f93\u5165\u552f\u4e00\u4e14\u975e\u7a7a\u7684\u89c6\u89d2\u540d\u79f0\u3002",
+      savePrompt: "\u5c06\u5f53\u524d\u89c6\u89d2\u4fdd\u5b58\u4e3a"
     } : {
       region: "Saved views",
       overview: "Overview",
@@ -483,9 +483,10 @@
   IMB.fitToGroups = function (map, groups) {
     var result = originalFitToGroups.apply(IMB, arguments);
     if (map && map.__imbSavedViews) {
-      window.setTimeout(function () {
+      window.clearTimeout(map.__imbSavedViewsOverviewTimer);
+      map.__imbSavedViewsOverviewTimer = window.setTimeout(function () {
         map.__imbSavedViews.captureOverview();
-      }, 0);
+      }, 260);
     }
     return result;
   };

--- a/scripts/mapcore/resources/templates/saved-views.js
+++ b/scripts/mapcore/resources/templates/saved-views.js
@@ -89,8 +89,44 @@
     var catalog = payload.catalog && payload.catalog.saved_views
       ? payload.catalog.saved_views
       : {};
+    var zh = IMB.text(document.documentElement.lang).toLocaleLowerCase().indexOf("zh") === 0;
+    var defaults = zh ? {
+      region: "保存视角",
+      overview: "总览",
+      save: "+ 保存视角",
+      manage: "管理视角",
+      close: "关闭",
+      default_name: "视角",
+      empty: "暂无保存视角。",
+      rename: "重命名",
+      delete: "删除",
+      rename_prompt: "重命名视角",
+      delete_confirm: "删除“{name}”吗？",
+      go_to: "前往 {name}",
+      limit_reached: "最多保存 8 个视角。",
+      save_hint: "保存当前地图中心和缩放级别。",
+      duplicate_name: "请输入唯一且非空的视角名称。",
+      save_prompt: "将当前视角保存为"
+    } : {
+      region: "Saved views",
+      overview: "Overview",
+      save: "+ Save view",
+      manage: "Manage saved views",
+      close: "Close",
+      default_name: "View",
+      empty: "No saved views yet.",
+      rename: "Rename",
+      delete: "Delete",
+      rename_prompt: "Rename view",
+      delete_confirm: "Delete “{name}”?",
+      go_to: "Go to {name}",
+      limit_reached: "You can save up to 8 views.",
+      save_hint: "Save the current map center and zoom.",
+      duplicate_name: "Use a unique, non-empty view name.",
+      save_prompt: "Save current view as"
+    };
     function label(key, fallback) {
-      return IMB.text(catalog[key] || fallback || key);
+      return IMB.text(catalog[key] || defaults[key] || fallback || key);
     }
 
     var header = document.querySelector(".imb-header");
@@ -161,6 +197,7 @@
     document.body.appendChild(dialog);
 
     function updateQA() {
+      var center = map.getCenter();
       IMB.qa.savedViews = {
         count: views.length,
         max: MAX_VIEWS,
@@ -168,6 +205,8 @@
         storageKey: storageKey,
         activeId: activeId,
         overviewCaptured: Boolean(overview),
+        currentCenter: [Number(center.lat), Number(center.lng)],
+        currentZoom: Number(map.getZoom()),
         views: views.map(function (view) {
           return {
             id: view.id,

--- a/scripts/mapcore/resources/templates/saved-views.js
+++ b/scripts/mapcore/resources/templates/saved-views.js
@@ -10,68 +10,109 @@
   var originalSetupMap = IMB.setupMap;
   var originalFitToGroups = IMB.fitToGroups;
 
-  function finiteNumber(value) {
-    var numeric = Number(value);
-    return Number.isFinite(numeric) ? numeric : null;
+  function numberOrNull(value) {
+    var parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
   }
 
-  function hashString(value) {
-    var hash = 2166136261;
-    var source = String(value || "");
-    for (var index = 0; index < source.length; index += 1) {
-      hash ^= source.charCodeAt(index);
-      hash = Math.imul(hash, 16777619);
-    }
-    return (hash >>> 0).toString(36);
+  function hash(value) {
+    var result = 2166136261;
+    String(value || "").split("").forEach(function (character) {
+      result ^= character.charCodeAt(0);
+      result = Math.imul(result, 16777619);
+    });
+    return (result >>> 0).toString(36);
   }
 
-  function mapIdentity(payload) {
-    var spec = payload && payload.spec && typeof payload.spec === "object" ? payload.spec : {};
-    var layers = payload && Array.isArray(payload.layers) ? payload.layers : [];
-    var layerSignature = layers.map(function (layer, index) {
-      return IMB.layerId(layer, index) + ":" + Number(layer && layer.count || 0);
-    }).join("|");
-    return [
+  function labels(payload) {
+    var zh = IMB.text(document.documentElement.lang).toLocaleLowerCase().indexOf("zh") === 0;
+    var fallback = zh ? {
+      region: "保存视角",
+      overview: "总览",
+      save: "+ 保存视角",
+      manage: "管理视角",
+      close: "关闭",
+      defaultName: "视角",
+      empty: "暂无保存视角。",
+      rename: "重命名",
+      remove: "删除",
+      renamePrompt: "重命名视角",
+      deleteConfirm: "删除“{name}”吗？",
+      goTo: "前往 {name}",
+      limit: "最多保存 8 个视角。",
+      saveHint: "保存当前地图中心和缩放级别。",
+      invalidName: "请输入唯一且非空的视角名称。",
+      savePrompt: "将当前视角保存为"
+    } : {
+      region: "Saved views",
+      overview: "Overview",
+      save: "+ Save view",
+      manage: "Manage saved views",
+      close: "Close",
+      defaultName: "View",
+      empty: "No saved views yet.",
+      rename: "Rename",
+      remove: "Delete",
+      renamePrompt: "Rename view",
+      deleteConfirm: "Delete “{name}”?",
+      goTo: "Go to {name}",
+      limit: "You can save up to 8 views.",
+      saveHint: "Save the current map center and zoom.",
+      invalidName: "Use a unique, non-empty view name.",
+      savePrompt: "Save current view as"
+    };
+    var configured = payload.catalog && payload.catalog.saved_views
+      ? payload.catalog.saved_views
+      : {};
+    Object.keys(configured).forEach(function (key) {
+      fallback[key] = IMB.text(configured[key]);
+    });
+    return fallback;
+  }
+
+  function storageFor(payload) {
+    var spec = payload.spec || {};
+    var layers = Array.isArray(payload.layers) ? payload.layers : [];
+    var identity = [
       window.location.pathname || "",
-      IMB.text(payload && payload.template || spec.template || ""),
+      IMB.text(payload.template || spec.template || ""),
       IMB.text(spec.title || ""),
-      layerSignature
+      layers.map(function (layer, index) {
+        return IMB.layerId(layer, index) + ":" + Number(layer && layer.count || 0);
+      }).join("|")
     ].join("::");
-  }
-
-  function storageAdapter(key) {
+    var key = "interactive-map-builder:saved-views:v1:" + hash(identity);
+    var memory = null;
     try {
       var probe = key + ":probe";
       window.localStorage.setItem(probe, "1");
       window.localStorage.removeItem(probe);
       return {
+        key: key,
         persistent: true,
-        read: function () { return window.localStorage.getItem(key); },
-        write: function (value) { window.localStorage.setItem(key, value); }
+        get: function () { return window.localStorage.getItem(key); },
+        set: function (value) { window.localStorage.setItem(key, value); }
       };
     } catch (_error) {
-      var memory = null;
       return {
+        key: key,
         persistent: false,
-        read: function () { return memory; },
-        write: function (value) { memory = value; }
+        get: function () { return memory; },
+        set: function (value) { memory = value; }
       };
     }
   }
 
-  function normalizeViews(raw) {
-    if (!Array.isArray(raw)) {
+  function normalizeViews(value) {
+    if (!Array.isArray(value)) {
       return [];
     }
-    return raw.slice(0, MAX_VIEWS).map(function (item, index) {
-      if (!item || typeof item !== "object") {
-        return null;
-      }
-      var name = IMB.text(item.name).trim();
-      var center = Array.isArray(item.center) ? item.center : [];
-      var latitude = finiteNumber(center[0]);
-      var longitude = finiteNumber(center[1]);
-      var zoom = finiteNumber(item.zoom);
+    return value.slice(0, MAX_VIEWS).map(function (item, index) {
+      var center = item && Array.isArray(item.center) ? item.center : [];
+      var latitude = numberOrNull(center[0]);
+      var longitude = numberOrNull(center[1]);
+      var zoom = numberOrNull(item && item.zoom);
+      var name = IMB.text(item && item.name).trim();
       if (!name || latitude === null || longitude === null || zoom === null) {
         return null;
       }
@@ -84,62 +125,25 @@
     }).filter(Boolean);
   }
 
-  function createController(map) {
-    var payload = IMB.parsePayload();
-    var catalog = payload.catalog && payload.catalog.saved_views
-      ? payload.catalog.saved_views
-      : {};
-    var zh = IMB.text(document.documentElement.lang).toLocaleLowerCase().indexOf("zh") === 0;
-    var defaults = zh ? {
-      region: "保存视角",
-      overview: "总览",
-      save: "+ 保存视角",
-      manage: "管理视角",
-      close: "关闭",
-      default_name: "视角",
-      empty: "暂无保存视角。",
-      rename: "重命名",
-      delete: "删除",
-      rename_prompt: "重命名视角",
-      delete_confirm: "删除“{name}”吗？",
-      go_to: "前往 {name}",
-      limit_reached: "最多保存 8 个视角。",
-      save_hint: "保存当前地图中心和缩放级别。",
-      duplicate_name: "请输入唯一且非空的视角名称。",
-      save_prompt: "将当前视角保存为"
-    } : {
-      region: "Saved views",
-      overview: "Overview",
-      save: "+ Save view",
-      manage: "Manage saved views",
-      close: "Close",
-      default_name: "View",
-      empty: "No saved views yet.",
-      rename: "Rename",
-      delete: "Delete",
-      rename_prompt: "Rename view",
-      delete_confirm: "Delete “{name}”?",
-      go_to: "Go to {name}",
-      limit_reached: "You can save up to 8 views.",
-      save_hint: "Save the current map center and zoom.",
-      duplicate_name: "Use a unique, non-empty view name.",
-      save_prompt: "Save current view as"
-    };
-    function label(key, fallback) {
-      return IMB.text(catalog[key] || defaults[key] || fallback || key);
-    }
-
-    var header = document.querySelector(".imb-header");
-    var heading = header && header.querySelector(".imb-heading");
-    if (!header || !heading) {
+  function readMapView(map) {
+    try {
+      var center = map.getCenter();
+      return {
+        center: [Number(center.lat), Number(center.lng)],
+        zoom: Number(map.getZoom())
+      };
+    } catch (_error) {
       return null;
     }
+  }
 
-    var storageKey = "interactive-map-builder:saved-views:v1:" + hashString(mapIdentity(payload));
-    var storage = storageAdapter(storageKey);
+  function createController(map) {
+    var payload = IMB.parsePayload();
+    var text = labels(payload);
+    var storage = storageFor(payload);
     var views = [];
     try {
-      views = normalizeViews(JSON.parse(storage.read() || "[]"));
+      views = normalizeViews(JSON.parse(storage.get() || "[]"));
     } catch (_error) {
       views = [];
     }
@@ -148,47 +152,47 @@
     var activeId = "overview";
     var navigating = false;
     var sequence = views.length;
+    var header = document.querySelector(".imb-header");
+    var heading = header && header.querySelector(".imb-heading");
+    if (!header || !heading) {
+      return null;
+    }
 
-    var root = IMB.element("nav", undefined, "imb-saved-views");
-    root.id = "imb-saved-views";
-    root.setAttribute("aria-label", label("region", "Saved views"));
-
+    var nav = IMB.element("nav", undefined, "imb-saved-views");
+    nav.id = "imb-saved-views";
+    nav.setAttribute("aria-label", text.region);
     var strip = IMB.element("div", undefined, "imb-saved-view-strip");
-    var overviewButton = IMB.element("button", label("overview", "Overview"), "imb-saved-view-chip is-active");
+    var overviewButton = IMB.element("button", text.overview, "imb-saved-view-chip is-active");
     overviewButton.id = "imb-saved-view-overview";
     overviewButton.type = "button";
     overviewButton.dataset.viewId = "overview";
     overviewButton.setAttribute("aria-pressed", "true");
-
     var listNode = IMB.element("div", undefined, "imb-saved-view-list");
     listNode.id = "imb-saved-view-list";
-
-    var addButton = IMB.element("button", label("save", "+ Save view"), "imb-saved-view-add");
+    var addButton = IMB.element("button", text.save, "imb-saved-view-add");
     addButton.id = "imb-saved-view-add";
     addButton.type = "button";
-
     var manageButton = IMB.element("button", "⋯", "imb-saved-view-manage");
     manageButton.id = "imb-saved-view-manage";
     manageButton.type = "button";
-    manageButton.title = label("manage", "Manage saved views");
-    manageButton.setAttribute("aria-label", manageButton.title);
-
+    manageButton.title = text.manage;
+    manageButton.setAttribute("aria-label", text.manage);
     strip.appendChild(overviewButton);
     strip.appendChild(listNode);
     strip.appendChild(addButton);
     strip.appendChild(manageButton);
-    root.appendChild(strip);
-    heading.insertAdjacentElement("afterend", root);
+    nav.appendChild(strip);
+    heading.insertAdjacentElement("afterend", nav);
 
     var dialog = document.createElement("dialog");
     dialog.id = "imb-saved-view-dialog";
     dialog.className = "imb-saved-view-dialog";
     var dialogCard = IMB.element("div", undefined, "imb-saved-view-dialog-card");
     var dialogHeader = IMB.element("div", undefined, "imb-saved-view-dialog-header");
-    dialogHeader.appendChild(IMB.element("h2", label("manage", "Manage saved views")));
+    dialogHeader.appendChild(IMB.element("h2", text.manage));
     var closeButton = IMB.element("button", "×", "imb-saved-view-dialog-close");
     closeButton.type = "button";
-    closeButton.setAttribute("aria-label", label("close", "Close"));
+    closeButton.setAttribute("aria-label", text.close);
     dialogHeader.appendChild(closeButton);
     var dialogList = IMB.element("div", undefined, "imb-saved-view-dialog-list");
     dialogCard.appendChild(dialogHeader);
@@ -196,17 +200,17 @@
     dialog.appendChild(dialogCard);
     document.body.appendChild(dialog);
 
-    function updateQA() {
-      var center = map.getCenter();
+    function syncQA() {
+      var current = readMapView(map);
       IMB.qa.savedViews = {
         count: views.length,
         max: MAX_VIEWS,
         persistent: storage.persistent,
-        storageKey: storageKey,
+        storageKey: storage.key,
         activeId: activeId,
         overviewCaptured: Boolean(overview),
-        currentCenter: [Number(center.lat), Number(center.lng)],
-        currentZoom: Number(map.getZoom()),
+        currentCenter: current ? current.center.slice() : [null, null],
+        currentZoom: current ? current.zoom : null,
         views: views.map(function (view) {
           return {
             id: view.id,
@@ -219,8 +223,8 @@
     }
 
     function persist() {
-      storage.write(JSON.stringify(views));
-      updateQA();
+      storage.set(JSON.stringify(views));
+      syncQA();
     }
 
     function setActive(identifier) {
@@ -228,54 +232,51 @@
       overviewButton.classList.toggle("is-active", activeId === "overview");
       overviewButton.setAttribute("aria-pressed", activeId === "overview" ? "true" : "false");
       Array.prototype.forEach.call(listNode.querySelectorAll("[data-view-id]"), function (node) {
-        var active = node.dataset.viewId === activeId;
-        node.classList.toggle("is-active", active);
-        node.setAttribute("aria-pressed", active ? "true" : "false");
+        var selected = node.dataset.viewId === activeId;
+        node.classList.toggle("is-active", selected);
+        node.setAttribute("aria-pressed", selected ? "true" : "false");
       });
-      updateQA();
+      syncQA();
     }
 
-    function defaultName() {
-      var base = label("default_name", "View");
-      var number = 1;
-      var existing = new Set(views.map(function (view) { return view.name.toLocaleLowerCase(); }));
-      while (existing.has((base + " " + number).toLocaleLowerCase())) {
-        number += 1;
-      }
-      return base + " " + number;
-    }
-
-    function nameAvailable(name, excludedId) {
+    function uniqueName(name, exceptId) {
       var normalized = IMB.text(name).trim().toLocaleLowerCase();
       return Boolean(normalized) && !views.some(function (view) {
-        return view.id !== excludedId && view.name.toLocaleLowerCase() === normalized;
+        return view.id !== exceptId && view.name.toLocaleLowerCase() === normalized;
       });
     }
 
-    function renderDialog() {
+    function nextName() {
+      var used = new Set(views.map(function (view) { return view.name.toLocaleLowerCase(); }));
+      var index = 1;
+      while (used.has((text.defaultName + " " + index).toLocaleLowerCase())) {
+        index += 1;
+      }
+      return text.defaultName + " " + index;
+    }
+
+    function renderManager() {
       dialogList.replaceChildren();
       if (!views.length) {
-        dialogList.appendChild(IMB.element("p", label("empty", "No saved views yet."), "imb-saved-view-empty"));
+        dialogList.appendChild(IMB.element("p", text.empty, "imb-saved-view-empty"));
         return;
       }
       views.forEach(function (view) {
         var row = IMB.element("div", undefined, "imb-saved-view-dialog-row");
         row.appendChild(IMB.element("span", view.name, "imb-saved-view-dialog-name"));
         var actions = IMB.element("div", undefined, "imb-saved-view-dialog-actions");
-        var rename = IMB.element("button", label("rename", "Rename"), "imb-button imb-button-quiet");
+        var rename = IMB.element("button", text.rename, "imb-button imb-button-quiet");
         rename.type = "button";
         rename.addEventListener("click", function () {
-          var proposed = window.prompt(label("rename_prompt", "Rename view"), view.name);
-          if (proposed === null) {
-            return;
+          var proposed = window.prompt(text.renamePrompt, view.name);
+          if (proposed !== null) {
+            renameView(view.id, proposed, true);
           }
-          renameView(view.id, proposed, true);
         });
-        var remove = IMB.element("button", label("delete", "Delete"), "imb-button imb-saved-view-delete");
+        var remove = IMB.element("button", text.remove, "imb-button imb-saved-view-delete");
         remove.type = "button";
         remove.addEventListener("click", function () {
-          var message = label("delete_confirm", "Delete this saved view?").replace("{name}", view.name);
-          if (window.confirm(message)) {
+          if (window.confirm(text.deleteConfirm.replace("{name}", view.name))) {
             deleteView(view.id);
           }
         });
@@ -286,55 +287,43 @@
       });
     }
 
-    function renderViews() {
+    function render() {
       listNode.replaceChildren();
       views.forEach(function (view) {
         var button = IMB.element("button", view.name, "imb-saved-view-chip");
         button.type = "button";
         button.dataset.viewId = view.id;
-        button.setAttribute("aria-pressed", activeId === view.id ? "true" : "false");
-        button.classList.toggle("is-active", activeId === view.id);
-        button.title = label("go_to", "Go to {name}").replace("{name}", view.name);
-        button.addEventListener("click", function () {
-          goToView(view.id);
-        });
+        button.title = text.goTo.replace("{name}", view.name);
+        button.addEventListener("click", function () { goToView(view.id); });
         listNode.appendChild(button);
       });
       addButton.disabled = views.length >= MAX_VIEWS;
-      addButton.title = addButton.disabled
-        ? label("limit_reached", "Saved-view limit reached.")
-        : label("save_hint", "Save the current map center and zoom.");
+      addButton.title = addButton.disabled ? text.limit : text.saveHint;
       manageButton.hidden = !views.length;
-      renderDialog();
-      updateQA();
+      renderManager();
+      setActive(activeId);
     }
 
     function captureOverview() {
       if (overview) {
         return false;
       }
-      var center = map.getCenter();
-      overview = {
-        center: [Number(center.lat), Number(center.lng)],
-        zoom: Number(map.getZoom())
-      };
-      updateQA();
+      var current = readMapView(map);
+      if (!current) {
+        return false;
+      }
+      overview = current;
+      syncQA();
       return true;
     }
 
-    function navigate(center, zoom, identifier) {
-      var latitude = finiteNumber(center && center[0]);
-      var longitude = finiteNumber(center && center[1]);
-      var targetZoom = finiteNumber(zoom);
-      if (latitude === null || longitude === null || targetZoom === null) {
+    function navigate(view, identifier) {
+      if (!view) {
         return false;
       }
       navigating = true;
       setActive(identifier);
-      map.flyTo([latitude, longitude], targetZoom, {
-        animate: true,
-        duration: 0.55
-      });
+      map.flyTo(view.center, view.zoom, { animate: true, duration: 0.55 });
       window.setTimeout(function () {
         navigating = false;
         setActive(identifier);
@@ -344,106 +333,98 @@
 
     function goToView(identifier) {
       var requested = IMB.text(identifier);
-      if (requested === "overview" || requested === label("overview", "Overview")) {
-        return overview ? navigate(overview.center, overview.zoom, "overview") : false;
+      if (requested === "overview" || requested === text.overview) {
+        return navigate(overview, "overview");
       }
       var view = views.find(function (candidate) {
         return candidate.id === requested || candidate.name === requested;
       });
-      return view ? navigate(view.center, view.zoom, view.id) : false;
+      return view ? navigate(view, view.id) : false;
     }
 
     function saveView(name, center, zoom, alertOnError) {
       if (views.length >= MAX_VIEWS) {
-        if (alertOnError) {
-          window.alert(label("limit_reached", "Saved-view limit reached."));
-        }
+        if (alertOnError) { window.alert(text.limit); }
         return false;
       }
       var resolvedName = IMB.text(name).trim();
-      if (!resolvedName || !nameAvailable(resolvedName, "")) {
-        if (alertOnError) {
-          window.alert(label("duplicate_name", "Use a unique, non-empty view name."));
-        }
+      if (!uniqueName(resolvedName, "")) {
+        if (alertOnError) { window.alert(text.invalidName); }
         return false;
       }
-      var mapCenter = map.getCenter();
-      var requestedCenter = Array.isArray(center) ? center : [mapCenter.lat, mapCenter.lng];
-      var latitude = finiteNumber(requestedCenter[0]);
-      var longitude = finiteNumber(requestedCenter[1]);
-      var targetZoom = finiteNumber(zoom === undefined ? map.getZoom() : zoom);
-      if (latitude === null || longitude === null || targetZoom === null) {
+      var current = readMapView(map);
+      var requestedCenter = Array.isArray(center)
+        ? [numberOrNull(center[0]), numberOrNull(center[1])]
+        : (current && current.center);
+      var requestedZoom = numberOrNull(zoom === undefined ? current && current.zoom : zoom);
+      if (!requestedCenter || requestedCenter[0] === null || requestedCenter[1] === null || requestedZoom === null) {
         return false;
       }
       sequence += 1;
       var view = {
         id: "view-" + Date.now().toString(36) + "-" + sequence.toString(36),
         name: resolvedName,
-        center: [latitude, longitude],
-        zoom: targetZoom
+        center: requestedCenter,
+        zoom: requestedZoom
       };
       views.push(view);
+      activeId = view.id;
       persist();
-      setActive(view.id);
-      renderViews();
+      render();
       return view.id;
     }
 
     function renameView(identifier, name, alertOnError) {
-      var view = views.find(function (candidate) { return candidate.id === IMB.text(identifier); });
+      var requested = IMB.text(identifier);
+      var view = views.find(function (candidate) { return candidate.id === requested; });
       var resolvedName = IMB.text(name).trim();
-      if (!view || !nameAvailable(resolvedName, view.id)) {
-        if (alertOnError) {
-          window.alert(label("duplicate_name", "Use a unique, non-empty view name."));
-        }
+      if (!view || !uniqueName(resolvedName, requested)) {
+        if (alertOnError) { window.alert(text.invalidName); }
         return false;
       }
       view.name = resolvedName;
       persist();
-      renderViews();
+      render();
       return true;
     }
 
     function deleteView(identifier) {
       var requested = IMB.text(identifier);
-      var before = views.length;
-      views = views.filter(function (view) { return view.id !== requested; });
-      if (views.length === before) {
+      var next = views.filter(function (view) { return view.id !== requested; });
+      if (next.length === views.length) {
         return false;
       }
+      views = next;
       if (activeId === requested) {
-        setActive("");
+        activeId = "";
       }
       persist();
-      renderViews();
+      render();
       return true;
     }
 
     function clearViews() {
       views = [];
-      setActive("");
+      activeId = "";
       persist();
-      renderViews();
+      render();
       return true;
     }
 
-    overviewButton.addEventListener("click", function () {
-      goToView("overview");
-    });
+    overviewButton.addEventListener("click", function () { goToView("overview"); });
     addButton.addEventListener("click", function () {
       if (views.length >= MAX_VIEWS) {
         return;
       }
-      var proposed = window.prompt(label("save_prompt", "Save current view as"), defaultName());
-      if (proposed === null) {
-        return;
+      var proposed = window.prompt(text.savePrompt, nextName());
+      if (proposed !== null) {
+        saveView(proposed, null, undefined, true);
       }
-      saveView(proposed, null, undefined, true);
     });
     manageButton.addEventListener("click", function () {
-      renderDialog();
+      renderManager();
       if (typeof dialog.showModal === "function") {
-        dialog.showModal();
+        if (!dialog.open) { dialog.showModal(); }
       } else {
         dialog.setAttribute("open", "open");
       }
@@ -460,7 +441,6 @@
         dialog.close();
       }
     });
-
     map.on("dragstart zoomstart", function () {
       if (!navigating) {
         setActive("");
@@ -470,18 +450,12 @@
     IMB.qa.actions.saveView = function (name, center, zoom) {
       return saveView(name, center, zoom, false);
     };
-    IMB.qa.actions.goToView = function (identifier) {
-      return goToView(identifier);
-    };
+    IMB.qa.actions.goToView = goToView;
     IMB.qa.actions.renameView = function (identifier, name) {
       return renameView(identifier, name, false);
     };
-    IMB.qa.actions.deleteView = function (identifier) {
-      return deleteView(identifier);
-    };
-    IMB.qa.actions.clearSavedViews = function () {
-      return clearViews();
-    };
+    IMB.qa.actions.deleteView = deleteView;
+    IMB.qa.actions.clearSavedViews = clearViews;
     IMB.qa.actions.listSavedViews = function () {
       return views.map(function (view) {
         return {
@@ -493,15 +467,10 @@
       });
     };
 
-    renderViews();
-    updateQA();
-
+    render();
     return {
       captureOverview: captureOverview,
-      goToView: goToView,
-      saveView: saveView,
-      renameView: renameView,
-      deleteView: deleteView
+      goToView: goToView
     };
   }
 
@@ -513,7 +482,7 @@
 
   IMB.fitToGroups = function (map, groups) {
     var result = originalFitToGroups.apply(IMB, arguments);
-    if (map && map.__imbSavedViews && typeof map.__imbSavedViews.captureOverview === "function") {
+    if (map && map.__imbSavedViews) {
       window.setTimeout(function () {
         map.__imbSavedViews.captureOverview();
       }, 0);

--- a/scripts/mapcore/resources/templates/saved-views.js
+++ b/scripts/mapcore/resources/templates/saved-views.js
@@ -1,0 +1,484 @@
+(function () {
+  "use strict";
+
+  var IMB = window.InteractiveMapBuilder;
+  if (!IMB || typeof IMB.setupMap !== "function" || typeof IMB.fitToGroups !== "function") {
+    return;
+  }
+
+  var MAX_VIEWS = 8;
+  var originalSetupMap = IMB.setupMap;
+  var originalFitToGroups = IMB.fitToGroups;
+
+  function finiteNumber(value) {
+    var numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  }
+
+  function hashString(value) {
+    var hash = 2166136261;
+    var source = String(value || "");
+    for (var index = 0; index < source.length; index += 1) {
+      hash ^= source.charCodeAt(index);
+      hash = Math.imul(hash, 16777619);
+    }
+    return (hash >>> 0).toString(36);
+  }
+
+  function mapIdentity(payload) {
+    var spec = payload && payload.spec && typeof payload.spec === "object" ? payload.spec : {};
+    var layers = payload && Array.isArray(payload.layers) ? payload.layers : [];
+    var layerSignature = layers.map(function (layer, index) {
+      return IMB.layerId(layer, index) + ":" + Number(layer && layer.count || 0);
+    }).join("|");
+    return [
+      window.location.pathname || "",
+      IMB.text(payload && payload.template || spec.template || ""),
+      IMB.text(spec.title || ""),
+      layerSignature
+    ].join("::");
+  }
+
+  function storageAdapter(key) {
+    try {
+      var probe = key + ":probe";
+      window.localStorage.setItem(probe, "1");
+      window.localStorage.removeItem(probe);
+      return {
+        persistent: true,
+        read: function () { return window.localStorage.getItem(key); },
+        write: function (value) { window.localStorage.setItem(key, value); }
+      };
+    } catch (_error) {
+      var memory = null;
+      return {
+        persistent: false,
+        read: function () { return memory; },
+        write: function (value) { memory = value; }
+      };
+    }
+  }
+
+  function normalizeViews(raw) {
+    if (!Array.isArray(raw)) {
+      return [];
+    }
+    return raw.slice(0, MAX_VIEWS).map(function (item, index) {
+      if (!item || typeof item !== "object") {
+        return null;
+      }
+      var name = IMB.text(item.name).trim();
+      var center = Array.isArray(item.center) ? item.center : [];
+      var latitude = finiteNumber(center[0]);
+      var longitude = finiteNumber(center[1]);
+      var zoom = finiteNumber(item.zoom);
+      if (!name || latitude === null || longitude === null || zoom === null) {
+        return null;
+      }
+      return {
+        id: IMB.text(item.id || ("view-" + (index + 1))),
+        name: name,
+        center: [latitude, longitude],
+        zoom: zoom
+      };
+    }).filter(Boolean);
+  }
+
+  function createController(map) {
+    var payload = IMB.parsePayload();
+    var catalog = payload.catalog && payload.catalog.saved_views
+      ? payload.catalog.saved_views
+      : {};
+    function label(key, fallback) {
+      return IMB.text(catalog[key] || fallback || key);
+    }
+
+    var header = document.querySelector(".imb-header");
+    var heading = header && header.querySelector(".imb-heading");
+    if (!header || !heading) {
+      return null;
+    }
+
+    var storageKey = "interactive-map-builder:saved-views:v1:" + hashString(mapIdentity(payload));
+    var storage = storageAdapter(storageKey);
+    var views = [];
+    try {
+      views = normalizeViews(JSON.parse(storage.read() || "[]"));
+    } catch (_error) {
+      views = [];
+    }
+
+    var overview = null;
+    var activeId = "overview";
+    var navigating = false;
+    var sequence = views.length;
+
+    var root = IMB.element("nav", undefined, "imb-saved-views");
+    root.id = "imb-saved-views";
+    root.setAttribute("aria-label", label("region", "Saved views"));
+
+    var strip = IMB.element("div", undefined, "imb-saved-view-strip");
+    var overviewButton = IMB.element("button", label("overview", "Overview"), "imb-saved-view-chip is-active");
+    overviewButton.id = "imb-saved-view-overview";
+    overviewButton.type = "button";
+    overviewButton.dataset.viewId = "overview";
+    overviewButton.setAttribute("aria-pressed", "true");
+
+    var listNode = IMB.element("div", undefined, "imb-saved-view-list");
+    listNode.id = "imb-saved-view-list";
+
+    var addButton = IMB.element("button", label("save", "+ Save view"), "imb-saved-view-add");
+    addButton.id = "imb-saved-view-add";
+    addButton.type = "button";
+
+    var manageButton = IMB.element("button", "⋯", "imb-saved-view-manage");
+    manageButton.id = "imb-saved-view-manage";
+    manageButton.type = "button";
+    manageButton.title = label("manage", "Manage saved views");
+    manageButton.setAttribute("aria-label", manageButton.title);
+
+    strip.appendChild(overviewButton);
+    strip.appendChild(listNode);
+    strip.appendChild(addButton);
+    strip.appendChild(manageButton);
+    root.appendChild(strip);
+    heading.insertAdjacentElement("afterend", root);
+
+    var dialog = document.createElement("dialog");
+    dialog.id = "imb-saved-view-dialog";
+    dialog.className = "imb-saved-view-dialog";
+    var dialogCard = IMB.element("div", undefined, "imb-saved-view-dialog-card");
+    var dialogHeader = IMB.element("div", undefined, "imb-saved-view-dialog-header");
+    dialogHeader.appendChild(IMB.element("h2", label("manage", "Manage saved views")));
+    var closeButton = IMB.element("button", "×", "imb-saved-view-dialog-close");
+    closeButton.type = "button";
+    closeButton.setAttribute("aria-label", label("close", "Close"));
+    dialogHeader.appendChild(closeButton);
+    var dialogList = IMB.element("div", undefined, "imb-saved-view-dialog-list");
+    dialogCard.appendChild(dialogHeader);
+    dialogCard.appendChild(dialogList);
+    dialog.appendChild(dialogCard);
+    document.body.appendChild(dialog);
+
+    function updateQA() {
+      IMB.qa.savedViews = {
+        count: views.length,
+        max: MAX_VIEWS,
+        persistent: storage.persistent,
+        storageKey: storageKey,
+        activeId: activeId,
+        overviewCaptured: Boolean(overview),
+        views: views.map(function (view) {
+          return {
+            id: view.id,
+            name: view.name,
+            center: view.center.slice(),
+            zoom: view.zoom
+          };
+        })
+      };
+    }
+
+    function persist() {
+      storage.write(JSON.stringify(views));
+      updateQA();
+    }
+
+    function setActive(identifier) {
+      activeId = IMB.text(identifier || "");
+      overviewButton.classList.toggle("is-active", activeId === "overview");
+      overviewButton.setAttribute("aria-pressed", activeId === "overview" ? "true" : "false");
+      Array.prototype.forEach.call(listNode.querySelectorAll("[data-view-id]"), function (node) {
+        var active = node.dataset.viewId === activeId;
+        node.classList.toggle("is-active", active);
+        node.setAttribute("aria-pressed", active ? "true" : "false");
+      });
+      updateQA();
+    }
+
+    function defaultName() {
+      var base = label("default_name", "View");
+      var number = 1;
+      var existing = new Set(views.map(function (view) { return view.name.toLocaleLowerCase(); }));
+      while (existing.has((base + " " + number).toLocaleLowerCase())) {
+        number += 1;
+      }
+      return base + " " + number;
+    }
+
+    function nameAvailable(name, excludedId) {
+      var normalized = IMB.text(name).trim().toLocaleLowerCase();
+      return Boolean(normalized) && !views.some(function (view) {
+        return view.id !== excludedId && view.name.toLocaleLowerCase() === normalized;
+      });
+    }
+
+    function renderDialog() {
+      dialogList.replaceChildren();
+      if (!views.length) {
+        dialogList.appendChild(IMB.element("p", label("empty", "No saved views yet."), "imb-saved-view-empty"));
+        return;
+      }
+      views.forEach(function (view) {
+        var row = IMB.element("div", undefined, "imb-saved-view-dialog-row");
+        row.appendChild(IMB.element("span", view.name, "imb-saved-view-dialog-name"));
+        var actions = IMB.element("div", undefined, "imb-saved-view-dialog-actions");
+        var rename = IMB.element("button", label("rename", "Rename"), "imb-button imb-button-quiet");
+        rename.type = "button";
+        rename.addEventListener("click", function () {
+          var proposed = window.prompt(label("rename_prompt", "Rename view"), view.name);
+          if (proposed === null) {
+            return;
+          }
+          renameView(view.id, proposed, true);
+        });
+        var remove = IMB.element("button", label("delete", "Delete"), "imb-button imb-saved-view-delete");
+        remove.type = "button";
+        remove.addEventListener("click", function () {
+          var message = label("delete_confirm", "Delete this saved view?").replace("{name}", view.name);
+          if (window.confirm(message)) {
+            deleteView(view.id);
+          }
+        });
+        actions.appendChild(rename);
+        actions.appendChild(remove);
+        row.appendChild(actions);
+        dialogList.appendChild(row);
+      });
+    }
+
+    function renderViews() {
+      listNode.replaceChildren();
+      views.forEach(function (view) {
+        var button = IMB.element("button", view.name, "imb-saved-view-chip");
+        button.type = "button";
+        button.dataset.viewId = view.id;
+        button.setAttribute("aria-pressed", activeId === view.id ? "true" : "false");
+        button.classList.toggle("is-active", activeId === view.id);
+        button.title = label("go_to", "Go to {name}").replace("{name}", view.name);
+        button.addEventListener("click", function () {
+          goToView(view.id);
+        });
+        listNode.appendChild(button);
+      });
+      addButton.disabled = views.length >= MAX_VIEWS;
+      addButton.title = addButton.disabled
+        ? label("limit_reached", "Saved-view limit reached.")
+        : label("save_hint", "Save the current map center and zoom.");
+      manageButton.hidden = !views.length;
+      renderDialog();
+      updateQA();
+    }
+
+    function captureOverview() {
+      if (overview) {
+        return false;
+      }
+      var center = map.getCenter();
+      overview = {
+        center: [Number(center.lat), Number(center.lng)],
+        zoom: Number(map.getZoom())
+      };
+      updateQA();
+      return true;
+    }
+
+    function navigate(center, zoom, identifier) {
+      var latitude = finiteNumber(center && center[0]);
+      var longitude = finiteNumber(center && center[1]);
+      var targetZoom = finiteNumber(zoom);
+      if (latitude === null || longitude === null || targetZoom === null) {
+        return false;
+      }
+      navigating = true;
+      setActive(identifier);
+      map.flyTo([latitude, longitude], targetZoom, {
+        animate: true,
+        duration: 0.55
+      });
+      window.setTimeout(function () {
+        navigating = false;
+        setActive(identifier);
+      }, 620);
+      return true;
+    }
+
+    function goToView(identifier) {
+      var requested = IMB.text(identifier);
+      if (requested === "overview" || requested === label("overview", "Overview")) {
+        return overview ? navigate(overview.center, overview.zoom, "overview") : false;
+      }
+      var view = views.find(function (candidate) {
+        return candidate.id === requested || candidate.name === requested;
+      });
+      return view ? navigate(view.center, view.zoom, view.id) : false;
+    }
+
+    function saveView(name, center, zoom, alertOnError) {
+      if (views.length >= MAX_VIEWS) {
+        if (alertOnError) {
+          window.alert(label("limit_reached", "Saved-view limit reached."));
+        }
+        return false;
+      }
+      var resolvedName = IMB.text(name).trim();
+      if (!resolvedName || !nameAvailable(resolvedName, "")) {
+        if (alertOnError) {
+          window.alert(label("duplicate_name", "Use a unique, non-empty view name."));
+        }
+        return false;
+      }
+      var mapCenter = map.getCenter();
+      var requestedCenter = Array.isArray(center) ? center : [mapCenter.lat, mapCenter.lng];
+      var latitude = finiteNumber(requestedCenter[0]);
+      var longitude = finiteNumber(requestedCenter[1]);
+      var targetZoom = finiteNumber(zoom === undefined ? map.getZoom() : zoom);
+      if (latitude === null || longitude === null || targetZoom === null) {
+        return false;
+      }
+      sequence += 1;
+      var view = {
+        id: "view-" + Date.now().toString(36) + "-" + sequence.toString(36),
+        name: resolvedName,
+        center: [latitude, longitude],
+        zoom: targetZoom
+      };
+      views.push(view);
+      persist();
+      setActive(view.id);
+      renderViews();
+      return view.id;
+    }
+
+    function renameView(identifier, name, alertOnError) {
+      var view = views.find(function (candidate) { return candidate.id === IMB.text(identifier); });
+      var resolvedName = IMB.text(name).trim();
+      if (!view || !nameAvailable(resolvedName, view.id)) {
+        if (alertOnError) {
+          window.alert(label("duplicate_name", "Use a unique, non-empty view name."));
+        }
+        return false;
+      }
+      view.name = resolvedName;
+      persist();
+      renderViews();
+      return true;
+    }
+
+    function deleteView(identifier) {
+      var requested = IMB.text(identifier);
+      var before = views.length;
+      views = views.filter(function (view) { return view.id !== requested; });
+      if (views.length === before) {
+        return false;
+      }
+      if (activeId === requested) {
+        setActive("");
+      }
+      persist();
+      renderViews();
+      return true;
+    }
+
+    function clearViews() {
+      views = [];
+      setActive("");
+      persist();
+      renderViews();
+      return true;
+    }
+
+    overviewButton.addEventListener("click", function () {
+      goToView("overview");
+    });
+    addButton.addEventListener("click", function () {
+      if (views.length >= MAX_VIEWS) {
+        return;
+      }
+      var proposed = window.prompt(label("save_prompt", "Save current view as"), defaultName());
+      if (proposed === null) {
+        return;
+      }
+      saveView(proposed, null, undefined, true);
+    });
+    manageButton.addEventListener("click", function () {
+      renderDialog();
+      if (typeof dialog.showModal === "function") {
+        dialog.showModal();
+      } else {
+        dialog.setAttribute("open", "open");
+      }
+    });
+    closeButton.addEventListener("click", function () {
+      if (typeof dialog.close === "function") {
+        dialog.close();
+      } else {
+        dialog.removeAttribute("open");
+      }
+    });
+    dialog.addEventListener("click", function (event) {
+      if (event.target === dialog && typeof dialog.close === "function") {
+        dialog.close();
+      }
+    });
+
+    map.on("dragstart zoomstart", function () {
+      if (!navigating) {
+        setActive("");
+      }
+    });
+
+    IMB.qa.actions.saveView = function (name, center, zoom) {
+      return saveView(name, center, zoom, false);
+    };
+    IMB.qa.actions.goToView = function (identifier) {
+      return goToView(identifier);
+    };
+    IMB.qa.actions.renameView = function (identifier, name) {
+      return renameView(identifier, name, false);
+    };
+    IMB.qa.actions.deleteView = function (identifier) {
+      return deleteView(identifier);
+    };
+    IMB.qa.actions.clearSavedViews = function () {
+      return clearViews();
+    };
+    IMB.qa.actions.listSavedViews = function () {
+      return views.map(function (view) {
+        return {
+          id: view.id,
+          name: view.name,
+          center: view.center.slice(),
+          zoom: view.zoom
+        };
+      });
+    };
+
+    renderViews();
+    updateQA();
+
+    return {
+      captureOverview: captureOverview,
+      goToView: goToView,
+      saveView: saveView,
+      renameView: renameView,
+      deleteView: deleteView
+    };
+  }
+
+  IMB.setupMap = function () {
+    var map = originalSetupMap.apply(IMB, arguments);
+    map.__imbSavedViews = createController(map);
+    return map;
+  };
+
+  IMB.fitToGroups = function (map, groups) {
+    var result = originalFitToGroups.apply(IMB, arguments);
+    if (map && map.__imbSavedViews && typeof map.__imbSavedViews.captureOverview === "function") {
+      window.setTimeout(function () {
+        map.__imbSavedViews.captureOverview();
+      }, 0);
+    }
+    return result;
+  };
+}());

--- a/scripts/mapcore/version.py
+++ b/scripts/mapcore/version.py
@@ -1,5 +1,5 @@
 """Package and deterministic engine version."""
 
-__version__ = "0.4.4"
+__version__ = "0.5.0"
 
 __all__ = ["__version__"]

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -76,6 +76,8 @@ def test_skill_package_is_lean_complete_and_deterministic(tmp_path: Path):
         "interactive-map-builder/scripts/mapcore/resources/templates/atlas-studio-light.css",
         "interactive-map-builder/scripts/mapcore/resources/templates/multilayer-enhancements.css",
         "interactive-map-builder/scripts/mapcore/resources/templates/multilayer-enhancements.js",
+        "interactive-map-builder/scripts/mapcore/resources/templates/saved-views.css",
+        "interactive-map-builder/scripts/mapcore/resources/templates/saved-views.js",
         "interactive-map-builder/scripts/mapcore/visual_defaults.py",
         "interactive-map-builder/scripts/mapcore/resources/vendor/leaflet-1.9.4/leaflet.js",
         "interactive-map-builder/PACKAGE_MANIFEST.json",

--- a/tests/test_v050_saved_views.py
+++ b/tests/test_v050_saved_views.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from map_builder import build_map
+
+
+pytestmark = pytest.mark.browser
+sync_playwright = pytest.importorskip("playwright.sync_api").sync_playwright
+
+
+def _write_project(project: Path, template: str, locale: str) -> Path:
+    project.mkdir(parents=True)
+    places = gpd.GeoDataFrame(
+        {
+            "id": ["a", "b", "c"],
+            "name": ["Alpha", "Bravo", "Charlie"],
+            "kind": ["A", "B", "A"],
+        },
+        geometry=[
+            Point(116.38, 39.90),
+            Point(116.42, 39.92),
+            Point(116.46, 39.94),
+        ],
+        crs="EPSG:4326",
+    )
+    places.to_file(project / "places.geojson", driver="GeoJSON")
+
+    layer = {
+        "id": "places",
+        "name": "Places",
+        "source": {"path": "places.geojson"},
+        "id_field": "id",
+        "label_field": "name",
+        "search_fields": ["name"],
+        "filter_fields": ["kind"],
+        "card_fields": ["kind"],
+        "sort_fields": ["name"],
+    }
+    spec = {
+        "schema_version": "1.1",
+        "template": template,
+        "title": "Saved Views Test",
+        "locale": locale,
+        "layers": [layer],
+        "basemaps": [],
+        "map": {
+            "controls": {
+                "fullscreen": True,
+                "scale": True,
+                "basemap_switcher": True,
+                "layer_control": True,
+                "legend": True,
+            }
+        },
+        "static": {"enabled": False},
+    }
+    if template == "map-list":
+        spec["primary_layer"] = "places"
+
+    spec_path = project / "map_spec.json"
+    spec_path.write_text(json.dumps(spec, ensure_ascii=False, indent=2), encoding="utf-8")
+    return spec_path
+
+
+@pytest.mark.parametrize(
+    ("template", "locale", "overview_label", "save_label"),
+    [
+        ("map-list", "en-US", "Overview", "+ Save view"),
+        ("multilayer", "zh-CN", "总览", "+ 保存视角"),
+    ],
+)
+def test_saved_views_navigation_persistence_and_management(
+    tmp_path: Path,
+    template: str,
+    locale: str,
+    overview_label: str,
+    save_label: str,
+) -> None:
+    spec_path = _write_project(tmp_path / template, template, locale)
+    dist = tmp_path / (template + "-dist")
+    build_map(spec_path, dist)
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 900})
+        page.goto((dist / "map.html").resolve().as_uri())
+        page.wait_for_function(
+            "document.documentElement.dataset.imbReady === 'true'",
+            timeout=15_000,
+        )
+        page.wait_for_function(
+            "window.__interactiveMapBuilderQA.savedViews"
+            " && window.__interactiveMapBuilderQA.savedViews.overviewCaptured === true",
+            timeout=5_000,
+        )
+
+        qa = page.evaluate("window.__interactiveMapBuilderQA")
+        assert qa["errors"] == []
+        assert qa["savedViews"]["max"] == 8
+        assert qa["savedViews"]["persistent"] is True
+        assert page.locator("#imb-saved-view-overview").inner_text() == overview_label
+        assert page.locator("#imb-saved-view-add").inner_text() == save_label
+
+        assert page.evaluate("window.__interactiveMapBuilderQA.actions.clearSavedViews()")
+        view_id = page.evaluate(
+            "window.__interactiveMapBuilderQA.actions.saveView"
+            "('Site 1', [39.925, 116.425], 14)"
+        )
+        assert isinstance(view_id, str) and view_id
+        assert page.locator("#imb-saved-view-list .imb-saved-view-chip").inner_text() == "Site 1"
+
+        assert page.evaluate(
+            "window.__interactiveMapBuilderQA.actions.goToView('Site 1')"
+        )
+        page.wait_for_function(
+            "Math.abs(window.__interactiveMapBuilderQA.savedViews.currentZoom - 14) < 0.01"
+            " && Math.abs(window.__interactiveMapBuilderQA.savedViews.currentCenter[0] - 39.925) < 0.001"
+            " && Math.abs(window.__interactiveMapBuilderQA.savedViews.currentCenter[1] - 116.425) < 0.001",
+            timeout=5_000,
+        )
+
+        page.reload()
+        page.wait_for_function(
+            "document.documentElement.dataset.imbReady === 'true'",
+            timeout=15_000,
+        )
+        page.wait_for_function(
+            "window.__interactiveMapBuilderQA.actions"
+            " && typeof window.__interactiveMapBuilderQA.actions.listSavedViews === 'function'",
+            timeout=5_000,
+        )
+        persisted = page.evaluate(
+            "window.__interactiveMapBuilderQA.actions.listSavedViews()"
+        )
+        assert [item["name"] for item in persisted] == ["Site 1"]
+        persisted_id = persisted[0]["id"]
+
+        assert page.evaluate(
+            "([id]) => window.__interactiveMapBuilderQA.actions.renameView(id, 'Site A')",
+            [persisted_id],
+        )
+        assert page.locator("#imb-saved-view-list .imb-saved-view-chip").inner_text() == "Site A"
+        assert page.evaluate(
+            "([id]) => window.__interactiveMapBuilderQA.actions.deleteView(id)",
+            [persisted_id],
+        )
+        assert page.locator("#imb-saved-view-list .imb-saved-view-chip").count() == 0
+
+        assert page.evaluate("window.__interactiveMapBuilderQA.actions.clearSavedViews()")
+        for index in range(8):
+            saved = page.evaluate(
+                "([name, offset]) => window.__interactiveMapBuilderQA.actions.saveView"
+                "(name, [39.90 + offset, 116.40 + offset], 13)",
+                [f"View {index + 1}", index * 0.001],
+            )
+            assert saved
+        assert page.evaluate(
+            "window.__interactiveMapBuilderQA.actions.saveView"
+            "('View 9', [39.99, 116.49], 13)"
+        ) is False
+        assert page.locator("#imb-saved-view-list .imb-saved-view-chip").count() == 8
+        assert page.locator("#imb-saved-view-add").is_disabled()
+        browser.close()


### PR DESCRIPTION
## Summary

Adds the v0.5 Saved Views workflow agreed for Interactive Map Builder.

- Adds a shared Saved Views controller to both `map-list` and `multilayer` without adding a new template or changing MapSpec.
- Places `Overview`, named views, and `+ Save view` in the header between the map title and existing right-side summary/actions.
- Saves only `Center + Zoom`, with up to 8 named views.
- Persists views in browser-local storage for the same generated map; views do not modify the HTML or MapSpec and are not transferred to another browser/device.
- Supports one-click return, rename, and delete.
- Includes Chinese and English UI text.
- Keeps experimental linked/data analysis out of the v0.5 scope.
- Adds Playwright coverage for both existing templates plus package-distribution coverage for the new shared assets.

## Acceptance focus

1. Open either existing map template and see `Overview` plus `+ Save view` in the header.
2. Save a named center/zoom, move elsewhere, and return to the same center/zoom.
3. Refresh/reopen the same generated map in the same browser and keep saved views.
4. Rename/delete saved views.
5. Enforce an 8-view maximum.
6. Preserve existing search, filter, layer, legend, and selection behavior.
7. No MapSpec/schema or template-family expansion.
